### PR TITLE
Fix journal icon stuck in front of other icons bug

### DIFF
--- a/UIInfoSuite2/Infrastucture/IconHandler.cs
+++ b/UIInfoSuite2/Infrastucture/IconHandler.cs
@@ -26,7 +26,7 @@ namespace UIInfoSuite.Infrastructure
         {
             int yPos = Game1.options.zoomButtons ? 290 : 260;
             int xPosition = Tools.GetWidthInPlayArea() - 70 - 48 * _amountOfVisibleIcons.Value;
-            if (Game1.player.questLog.Any())
+            if (Game1.player.questLog.Any() || Game1.player.team.specialOrders.Any())
             {
                 xPosition -= 65;
             }


### PR DESCRIPTION
Instead of player.questlog, special orders/Qi orders are managed by player.team.specialOrders.  This will ensure the icon shifts as needed for these post-1.5 quests.  An alternative to check for these quests in the log may be the visibleQuestCount() function in StardewValley.Farmer.