### PR TITLE
Ginger island rain Icons

### DIFF
--- a/UIInfoSuite2/Infrastucture/LanguageKeys.cs
+++ b/UIInfoSuite2/Infrastucture/LanguageKeys.cs
@@ -12,6 +12,8 @@
         public const string RainNextDay = "RainNextDay";
         public const string ThunderstormNextDay = "ThunderstormNextDay";
         public const string SnowNextDay = "SnowNextDay";
+        public const string IslandRainNextDay = "IslandRainNextDay";
+        public const string IslandThunderstormNextDay = "IslandThunderstormNextDay";
         public const string HarvestPrice = "HarvestPrice";
         public const string LevelUp = "LevelUp";
         public const string Calendar = "Calendar";

--- a/UIInfoSuite2/Infrastucture/Tools.cs
+++ b/UIInfoSuite2/Infrastucture/Tools.cs
@@ -134,18 +134,26 @@ namespace UIInfoSuite.Infrastructure
 
         }
 
-        public static void SetSubTexture(Color[] sourceColors, Color[] destColors, int destWidth, Rectangle destBounds)
+        public static void SetSubTexture(Color[] sourceColors, Color[] destColors, int destWidth, Rectangle destBounds, bool overlay = false)
         {
             if(sourceColors.Length > destColors.Length || (destBounds.Width * destBounds.Height) > destColors.Length) {
                 return;
             }
+            var emptyColor = new Color(0, 0, 0, 0);
             var srcIdx = 0;
             for (var yOffset = 0; yOffset < destBounds.Height; yOffset++)
             {
                 for (var xOffset = 0; xOffset < destBounds.Width; xOffset++)
                 {
                     var idx = (destBounds.X + xOffset) + (destWidth * (yOffset + destBounds.Y));
-                    destColors[idx] = sourceColors[srcIdx++];
+                    Color sourcePixel = sourceColors[srcIdx++];
+                    
+                    // If using overlay mode, don't copy transparent pixels
+                    if (overlay && emptyColor.Equals(sourcePixel))
+                    {
+                        continue;
+                    }
+                    destColors[idx] = sourcePixel;
                 }
             }
         }

--- a/UIInfoSuite2/UIElements/ShowRainyDayIcon.cs
+++ b/UIInfoSuite2/UIElements/ShowRainyDayIcon.cs
@@ -14,20 +14,28 @@ namespace UIInfoSuite.UIElements
     {
         #region Properties
 
-        private bool _IsNextDayRainy;
-        Rectangle? _weatherIconSpriteLocation;
-        private string _hoverText;
-        private ClickableTextureComponent _rainyDayIcon;
+        private class LocationWeather
+        {
+            internal bool IsRainyTomorrow { get; set; }
+            internal Rectangle? SpriteLocation { get; set; }
+            internal string HoverText { get; set; }
+            internal ClickableTextureComponent IconComponent { get; set; }
+        }
+
+        private readonly LocationWeather _valleyWeather = new();
+        private readonly LocationWeather _islandWeather = new();
         private Texture2D _iconSheet;
 
-        private Color[] _weatherIconColors = null;
-        private const int WeatherSheetWidth = 45;
-        private const int WeatherSheetHeight = 15;
-        
+        private Color[] _weatherIconColors;
+        private const int WeatherSheetWidth = 81;
+        private const int WeatherSheetHeight = 18;
+
         private readonly IModHelper _helper;
+
         #endregion
 
         #region Lifecycle
+
         public ShowRainyDayIcon(IModHelper helper)
         {
             _helper = helper;
@@ -51,42 +59,89 @@ namespace UIInfoSuite.UIElements
                 _helper.Events.Display.RenderedHud += OnRenderedHud;
             }
         }
+
         #endregion
 
         #region Event subscriptions
+
         private void OnRenderingHud(object sender, RenderingHudEventArgs e)
         {
             GetWeatherIconSpriteLocation();
 
-            // Draw icon
-            if (!Game1.eventUp && _IsNextDayRainy && _weatherIconSpriteLocation.HasValue)
+            if (Game1.eventUp)
             {
-                Point iconPosition = IconHandler.Handler.GetNewIconPosition();
-                _rainyDayIcon =
-                    new ClickableTextureComponent(
-                        new Rectangle(iconPosition.X, iconPosition.Y, 40, 40),
-                        _iconSheet,
-                        _weatherIconSpriteLocation.Value,
-                        8 / 3f);
-                _rainyDayIcon.draw(Game1.spriteBatch);
+                return;
+            }
+
+            RenderLocationWeatherIcon(_valleyWeather);
+            if (HasVisitedIsland())
+            {
+                RenderLocationWeatherIcon(_islandWeather);
             }
         }
 
         private void OnRenderedHud(object sender, RenderedHudEventArgs e)
         {
             // Show text on hover
-            if (_IsNextDayRainy && (_rainyDayIcon?.containsPoint(Game1.getMouseX(), Game1.getMouseY()) ?? false) && !String.IsNullOrEmpty(_hoverText))
+            RenderWeatherHoverText(_valleyWeather);
+            if (HasVisitedIsland())
+            {
+                RenderWeatherHoverText(_islandWeather);
+            }
+        }
+
+        private void RenderLocationWeatherIcon(LocationWeather weather)
+        {
+            // Escape if we don't have that weather or a sprite
+            if (!weather.IsRainyTomorrow || !weather.SpriteLocation.HasValue) return;
+            // Draw icon
+            var iconPosition = IconHandler.Handler.GetNewIconPosition();
+            weather.IconComponent =
+                new ClickableTextureComponent(
+                    new Rectangle(iconPosition.X, iconPosition.Y, 40, 40),
+                    _iconSheet,
+                    weather.SpriteLocation.Value,
+                    8 / 3f);
+            weather.IconComponent.draw(Game1.spriteBatch);
+        }
+
+        private static void RenderWeatherHoverText(LocationWeather weather)
+        {
+            var hasMouse = weather.IconComponent?.containsPoint(Game1.getMouseX(), Game1.getMouseY()) ?? false;
+            var hasText = !string.IsNullOrEmpty(weather.HoverText);
+            if (weather.IsRainyTomorrow && hasMouse && hasText)
             {
                 IClickableMenu.drawHoverText(
                     Game1.spriteBatch,
-                    _hoverText,
+                    weather.HoverText,
                     Game1.dialogueFont
                 );
             }
         }
+
         #endregion
 
         #region Logic
+
+        private static bool HasVisitedIsland()
+        {
+            return Game1.MasterPlayer.mailReceived.Contains("willyBoatFixed");
+        }
+
+        private static int GetWeatherForTomorrow()
+        {
+            var date = new WorldDate(Game1.Date);
+            ++date.TotalDays;
+            var tomorrowWeather = Game1.IsMasterGame
+                ? Game1.weatherForTomorrow
+                : Game1.netWorldState.Value.WeatherForTomorrow;
+            return Game1.getWeatherModificationsForDate(date, tomorrowWeather);
+        }
+
+        private static int GetIslandWeatherForTomorrow()
+        {
+            return Game1.netWorldState.Value.GetWeatherForLocation(GameLocation.LocationContext.Island).weatherForTomorrow.Value;
+        }
 
         /// <summary>
         /// Creates a custom tilesheet for weather icons.
@@ -95,76 +150,122 @@ namespace UIInfoSuite.UIElements
         ///</summary>
         private void CreateTileSheet()
         {
-
             ModEntry.MonitorObject.Log("Setting up icon sheet", LogLevel.Info);
             // Setup Texture sheet as a copy, so as not to disturb existing sprites
-            _iconSheet = new Texture2D(Game1.graphics.GraphicsDevice , WeatherSheetWidth, WeatherSheetHeight);
+            _iconSheet = new Texture2D(Game1.graphics.GraphicsDevice, WeatherSheetWidth, WeatherSheetHeight);
             _weatherIconColors = new Color[WeatherSheetWidth * WeatherSheetHeight];
             var cursorColors = new Color[Game1.mouseCursors.Width * Game1.mouseCursors.Height];
             var bounds = new Rectangle(0, 0, Game1.mouseCursors.Width, Game1.mouseCursors.Height);
             Game1.mouseCursors.GetData(cursorColors);
             var subTextureColors = new Color[15 * 15];
-            
+
             // Copy over the bits we want
             // Border from TV screen
             Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(499, 307, 15, 15));
             // Copy to each destination
-            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(0, 0, 15, 15));
-            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(15, 0, 15, 15));
-            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(30, 0, 15, 15));
+            for (var i = 0; i < 3; i++)
+            {
+                Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,
+                    new Rectangle(i * 15, 0, 15, 15));
+            }
+
+            // Add in expanded sprites for the island parrot
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(45, 0, 15, 15));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(63, 0, 15, 15));
 
             subTextureColors = new Color[13 * 13];
             // Rainy Weather
             Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(504, 333, 13, 13));
-            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(1, 1, 13, 13));
-            
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(1, 1, 13, 13));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(46, 1, 13, 13));
+
             // Stormy Weather
             Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(426, 346, 13, 13));
-            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(16, 1, 13, 13));
-            
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(16, 1, 13, 13));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(64, 1, 13, 13));
+
             // Snowy Weather
             Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(465, 346, 13, 13));
-            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth,  new Rectangle(31, 1, 13, 13));
-            
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(31, 1, 13, 13));
+
+            // Size of the parrot icon
+            subTextureColors = new Color[9 * 14];
+            // Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(155, 148, 9, 14));
+            Tools.GetSubTexture(subTextureColors, cursorColors, bounds, new Rectangle(146, 149, 9, 14));
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(54, 4, 9, 14),
+                true);
+            Tools.SetSubTexture(subTextureColors, _weatherIconColors, WeatherSheetWidth, new Rectangle(72, 4, 9, 14),
+                true);
+
             _iconSheet.SetData(_weatherIconColors);
         }
 
         private void GetWeatherIconSpriteLocation()
         {
-            WorldDate date = new WorldDate(Game1.Date);
-            ++date.TotalDays;
-            switch (!Game1.IsMasterGame ? Game1.getWeatherModificationsForDate(date, Game1.netWorldState.Value.WeatherForTomorrow) : Game1.getWeatherModificationsForDate(date, Game1.weatherForTomorrow))
+            SetValleyWeatherSprite();
+            if (HasVisitedIsland())
+            {
+                SetIslandWeatherSprite();
+            }
+        }
+
+        private void SetValleyWeatherSprite()
+        {
+            switch (GetWeatherForTomorrow())
             {
                 case Game1.weather_sunny:
                 case Game1.weather_debris:
                 case Game1.weather_festival:
                 case Game1.weather_wedding:
-                    _IsNextDayRainy = false;
+                    _valleyWeather.IsRainyTomorrow = false;
                     break;
 
                 case Game1.weather_rain:
-                    _IsNextDayRainy = true;
-                    _weatherIconSpriteLocation = new Rectangle(0, 0, 15, 15);
-                    _hoverText = _helper.SafeGetString(LanguageKeys.RainNextDay);
+                    _valleyWeather.IsRainyTomorrow = true;
+                    _valleyWeather.SpriteLocation = new Rectangle(0, 0, 15, 15);
+                    _valleyWeather.HoverText = _helper.SafeGetString(LanguageKeys.RainNextDay);
                     break;
 
                 case Game1.weather_lightning:
-                    _IsNextDayRainy = true;
-                    _weatherIconSpriteLocation = new Rectangle(15, 0, 15, 15);
-                    _hoverText = _helper.SafeGetString(LanguageKeys.ThunderstormNextDay);
+                    _valleyWeather.IsRainyTomorrow = true;
+                    _valleyWeather.SpriteLocation = new Rectangle(15, 0, 15, 15);
+                    _valleyWeather.HoverText = _helper.SafeGetString(LanguageKeys.ThunderstormNextDay);
                     break;
 
                 case Game1.weather_snow:
-                    _IsNextDayRainy = true;
-                    _weatherIconSpriteLocation = new Rectangle(30, 0, 15, 15);
-                    _hoverText = _helper.SafeGetString(LanguageKeys.SnowNextDay);
+                    _valleyWeather.IsRainyTomorrow = true;
+                    _valleyWeather.SpriteLocation = new Rectangle(30, 0, 15, 15);
+                    _valleyWeather.HoverText = _helper.SafeGetString(LanguageKeys.SnowNextDay);
                     break;
 
                 default:
-                    _IsNextDayRainy = false;
+                    _valleyWeather.IsRainyTomorrow = false;
                     break;
             }
         }
+
+        private void SetIslandWeatherSprite()
+        {
+            var islandWeather = GetIslandWeatherForTomorrow();
+            switch (islandWeather)
+            {
+                case Game1.weather_rain:
+                    _islandWeather.IsRainyTomorrow = true;
+                    _islandWeather.SpriteLocation = new Rectangle(45, 0, 18, 18);
+                    _islandWeather.HoverText = _helper.SafeGetString(LanguageKeys.IslandRainNextDay);
+                    break;
+
+                case Game1.weather_lightning:
+                    _islandWeather.IsRainyTomorrow = true;
+                    _islandWeather.SpriteLocation = new Rectangle(63, 0, 18, 18);
+                    _islandWeather.HoverText = _helper.SafeGetString(LanguageKeys.IslandThunderstormNextDay);
+                    break;
+                default:
+                    _islandWeather.IsRainyTomorrow = false;
+                    break;
+            }
+        }
+
         #endregion
     }
 }

--- a/UIInfoSuite2/i18n/de.json
+++ b/UIInfoSuite2/i18n/de.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Es wird morgen regnen",
   "ThunderstormNextDay": "Es wird morgen ein Gewitter geben",
   "SnowNextDay": "Es wird morgen schneien",
+  "IslandRainNextDay": "Es wird morgen regnen",
+  "IslandThunderstormNextDay": "Es wird morgen ein Gewitter geben",
   "DaysUntilToolIsUpgraded": "{0} Tage bis {1} fertig verbessert wurde",
   "ToolIsFinishedBeingUpgraded": "{0} ist fertig!",
   "NpcBirthday": "{0}'s Geburtstag",

--- a/UIInfoSuite2/i18n/default.json
+++ b/UIInfoSuite2/i18n/default.json
@@ -17,6 +17,8 @@
   "RainNextDay": "There will be rain tomorrow",
   "ThunderstormNextDay": "There will be a thunderstorm tomorrow",
   "SnowNextDay": "There will be snow tomorrow",
+  "IslandRainNextDay": "There will be rain on the island tomorrow",
+  "IslandThunderstormNextDay": "There will be a thunderstorm on the island tomorrow",
   "DaysUntilToolIsUpgraded": "{0} days until {1} is finished being upgraded",
   "ToolIsFinishedBeingUpgraded": "{0} is finished!",
   "NpcBirthday": "{0}'s birthday",

--- a/UIInfoSuite2/i18n/es.json
+++ b/UIInfoSuite2/i18n/es.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Mañana lloverá",
   "ThunderstormNextDay": "Mañana habrá tormenta eléctrica",
   "SnowNextDay": "Mañana nevará",
+  "IslandRainNextDay": "Mañana lloverá",
+  "IslandThunderstormNextDay": "Mañana habrá tormenta eléctrica",
   "DaysUntilToolIsUpgraded": "{0} días hasta que {1} termine de actualizarse",
   "ToolIsFinishedBeingUpgraded": "¡{0} está terminado!",
   "NpcBirthday": "Cumpleaños de {0}",

--- a/UIInfoSuite2/i18n/fr.json
+++ b/UIInfoSuite2/i18n/fr.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Il va pleuvoir demain",
   "ThunderstormNextDay": "Il va y avoir un orage demain",
   "SnowNextDay": "Il va neiger demain",
+  "IslandRainNextDay": "Il va pleuvoir demain",
+  "IslandThunderstormNextDay": "Il va y avoir un orage demain",
   "DaysUntilToolIsUpgraded": "{0} jours avant que {1} ne termine de s'améliorer",
   "ToolIsFinishedBeingUpgraded": "{0} est terminé!",
   "NpcBirthday": "Anniversaire de {0}",

--- a/UIInfoSuite2/i18n/hu.json
+++ b/UIInfoSuite2/i18n/hu.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Holnap esni fog az eső",
   "ThunderstormNextDay": "Holnap vihar lesz",
   "SnowNextDay": "Holnap esni fog a hó",
+  "IslandRainNextDay": "Holnap esni fog az eső",
+  "IslandThunderstormNextDay": "Holnap vihar lesz",
   "DaysUntilToolIsUpgraded": "{0} nap amíg {1} fejlesztése kész lesz",
   "ToolIsFinishedBeingUpgraded": "{0} fejlesztése be lett fejezve!",
   "NpcBirthday": "{0} születésnapja",

--- a/UIInfoSuite2/i18n/ja.json
+++ b/UIInfoSuite2/i18n/ja.json
@@ -17,6 +17,8 @@
   "RainNextDay": "明日は雨が降るでしょう",
   "ThunderstormNextDay": "明日は雷を伴った雨が降るでしょう",
   "SnowNextDay": "明日は雪が降るでしょう",
+  "IslandRainNextDay": "明日は雨が降るでしょう",
+  "IslandThunderstormNextDay": "明日は雷を伴った雨が降るでしょう",
   "DaysUntilToolIsUpgraded": "{1}のアップグレード完了まで{0}日",
   "ToolIsFinishedBeingUpgraded": "{0}のアップグレード完了！",
   "NpcBirthday": "{0}の誕生日",

--- a/UIInfoSuite2/i18n/ko.json
+++ b/UIInfoSuite2/i18n/ko.json
@@ -17,6 +17,8 @@
   "RainNextDay": "내일은 비가 올 것입니다",
   "ThunderstormNextDay": "내일은 뇌우가 올 것입니다",
   "SnowNextDay": "내일은 눈이 올 것입니다",
+  "IslandRainNextDay": "내일은 비가 올 것입니다",
+  "IslandThunderstormNextDay": "내일은 뇌우가 올 것입니다",
   "DaysUntilToolIsUpgraded": "{1} 완성까지 {0}일 남았습니다",
   "ToolIsFinishedBeingUpgraded": "{0}이(가) 완성됐습니다!",
   "NpcBirthday": "{0}의 생일입니다！",

--- a/UIInfoSuite2/i18n/pl.json
+++ b/UIInfoSuite2/i18n/pl.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Jutro będzie padać deszcz",
   "ThunderstormNextDay": "Jutro będzie burza",
   "SnowNextDay": "Jutro będzie padać śnieg",
+  "IslandRainNextDay": "Jutro będzie padać deszcz",
+  "IslandThunderstormNextDay": "Jutro będzie burza",
   "DaysUntilToolIsUpgraded": "{0} dni do zakończenia ulepszania: {1}",
   "ToolIsFinishedBeingUpgraded": "Ulepszanie zakończone: {0}!",
   "NpcBirthday": "{0} ma dzisiaj urodziny",

--- a/UIInfoSuite2/i18n/pt.json
+++ b/UIInfoSuite2/i18n/pt.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Vai chover amanhã",
   "ThunderstormNextDay": "Haverá uma tempestade amanhã",
   "SnowNextDay": "Vai nevar amanhã",
+  "IslandRainNextDay": "Vai chover amanhã",
+  "IslandThunderstormNextDay": "Haverá uma tempestade amanhã",
   "DaysUntilToolIsUpgraded": "{1} ficará pronto em {0} dia(s)",
   "ToolIsFinishedBeingUpgraded": "{0} está pronto!",
   "NpcBirthday": "Aniversariante do dia: {0}",

--- a/UIInfoSuite2/i18n/ru.json
+++ b/UIInfoSuite2/i18n/ru.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Завтра будет дождь",
   "ThunderstormNextDay": "Завтра будет гроза",
   "SnowNextDay": "Завтра будет снег",
+  "IslandRainNextDay": "Завтра будет дождь",
+  "IslandThunderstormNextDay": "Завтра будет гроза",
   "DaysUntilToolIsUpgraded": "{1} будет улучшено через {0} дней",
   "ToolIsFinishedBeingUpgraded": "{0} улучшено!",
   "NpcBirthday": "Сегодня день рождение {0}",

--- a/UIInfoSuite2/i18n/th.json
+++ b/UIInfoSuite2/i18n/th.json
@@ -17,6 +17,8 @@
   "RainNextDay": "พรุ่งนี้ฝนจะตก",
   "ThunderstormNextDay": "พรุ่งนี้จะมีพายุฝนฟ้าคะนอง",
   "SnowNextDay": "พรุ่งนี้จะมีหิมะตก",
+  "IslandRainNextDay": "พรุ่งนี้ฝนจะตก",
+  "IslandThunderstormNextDay": "พรุ่งนี้จะมีพายุฝนฟ้าคะนอง",
   "DaysUntilToolIsUpgraded": "{0} วัน จะอัพเกรด {1} เสร็จสิ้น",
   "ToolIsFinishedBeingUpgraded": "{0} เสร็จเรียบร้อย!",
   "NpcBirthday": "วันเกิดของ{0}",

--- a/UIInfoSuite2/i18n/tr.json
+++ b/UIInfoSuite2/i18n/tr.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Yarın yamur yağacak",
   "ThunderstormNextDay": "Yarın Fırtına olacak",
   "SnowNextDay": "Yarın kar yağacak",
+  "IslandRainNextDay": "Yarın yamur yağacak",
+  "IslandThunderstormNextDay": "Yarın Fırtına olacak",
   "DaysUntilToolIsUpgraded": "{1}'nın yükseltmesinin bitmesine {0} gün kaldı ",
   "ToolIsFinishedBeingUpgraded": "{0} hazır!",
   "NpcBirthday": "Doğum günü: {0}",

--- a/UIInfoSuite2/i18n/uk.json
+++ b/UIInfoSuite2/i18n/uk.json
@@ -17,6 +17,8 @@
   "RainNextDay": "Завтра буде дощ",
   "ThunderstormNextDay": "Завтра буде гроза",
   "SnowNextDay": "Завтра буде сніг",
+  "IslandRainNextDay": "Завтра буде дощ",
+  "IslandThunderstormNextDay": "Завтра буде гроза",
   "DaysUntilToolIsUpgraded": "Залишилося {0} дні(в), щоб {1} було оновлено",
   "ToolIsFinishedBeingUpgraded": "{0} оновлено!",
   "NpcBirthday": "{0} - день народження",

--- a/UIInfoSuite2/i18n/zh.json
+++ b/UIInfoSuite2/i18n/zh.json
@@ -17,6 +17,8 @@
   "RainNextDay": "明日有雨",
   "ThunderstormNextDay": "明日雷雨",
   "SnowNextDay": "明日有雪",
+  "IslandRainNextDay": "明日有雨",
+  "IslandThunderstormNextDay": "明日雷雨",
   "DaysUntilToolIsUpgraded": "{1}还有{0}天完成！",
   "ToolIsFinishedBeingUpgraded": "{0}完成了！",
   "NpcBirthday": "{0}的生日",


### PR DESCRIPTION
Well this is only overdue by like....a year.
Sorry this took so long, got distracted by some other life stuff.

Had to refactor a good chunk of `ShowRainyDayIcon.cs` otherwise it would've just been a slew of duplicated code to add in the island weather. Extracted most of it to some clean methods that work off of an internal data class.

Only _slight_ problem is that the island weather icon is slightly wider than the normal rain icon because of the parrot. 
This means that the island rain icon comes a _bit_ close to other icons when rendering, but I wanted to keep them the same size so I just kind of rolled with it. I might tackle it in the future by allowing icons to request a specific amount of width on the bar, but that's for another day.

Updated all the lang files to just use the default "It's going to rain/thunderstorm" text, but I think the parrot icon will get the point across.

LMK if you have any edits for me to make!
fixes #33 
fixes #166 