### PR TITLE
Show Seasonal Berry Icons

### DIFF
--- a/UIInfoSuite2/Infrastucture/LanguageKeys.cs
+++ b/UIInfoSuite2/Infrastucture/LanguageKeys.cs
@@ -27,5 +27,8 @@
         public const string LuckStatus6 = "LuckStatus6";
         public const string RobinBuildingStatus = "RobinBuildingStatus";
         public const string NpcBirthday = "NpcBirthday";
+        public const string CanFindSalmonberry = "CanFindSalmonberry";
+        public const string CanFindBlackberry = "CanFindBlackberry";
+        public const string CanFindHazelnut = "CanFindHazelnut";
     }
 }

--- a/UIInfoSuite2/Options/ModOptions.cs
+++ b/UIInfoSuite2/Options/ModOptions.cs
@@ -34,6 +34,7 @@ namespace UIInfoSuite.Options
         public bool HideMerchantWhenVisited { get; set; } = false;
         public bool ShowExactValue { get; set; } = false;
         public bool ShowRobinBuildingStatusIcon { get; set; } = true;
+        public bool ShowSeasonalBerry { get; set; } = true;
         public bool ShowTodaysGifts { get; set; } = true;
         public bool HideBirthdayIfFullFriendShip { get; set; } = true;
         public Dictionary<string, bool> ShowLocationOfFriends { get; set; } = new Dictionary<string, bool>();

--- a/UIInfoSuite2/Options/ModOptionsPageHandler.cs
+++ b/UIInfoSuite2/Options/ModOptionsPageHandler.cs
@@ -37,6 +37,7 @@ namespace UIInfoSuite.Options
         private readonly ShowQueenOfSauceIcon _showQueenOfSauceIcon;
         private readonly ShowToolUpgradeStatus _showToolUpgradeStatus;
         private readonly ShowRobinBuildingStatusIcon _showRobinBuildingStatusIcon;
+        private readonly ShowSeasonalBerry _showSeasonalBerry;
         private readonly ShowTodaysGifts _showTodaysGift;
 
         public ModOptionsPageHandler(IModHelper helper, ModOptions _options, bool showPersonalConfigButton)
@@ -63,6 +64,7 @@ namespace UIInfoSuite.Options
             _showCropAndBarrelTime = new ShowCropAndBarrelTime(helper);
             _showToolUpgradeStatus = new ShowToolUpgradeStatus(helper);
             _showRobinBuildingStatusIcon = new ShowRobinBuildingStatusIcon(helper);
+            _showSeasonalBerry = new ShowSeasonalBerry(helper);
             _showTodaysGift = new ShowTodaysGifts(helper);
 
             _elementsToDispose = new List<IDisposable>()
@@ -81,7 +83,8 @@ namespace UIInfoSuite.Options
                 _shopHarvestPrices,
                 _showQueenOfSauceIcon,
                 _showToolUpgradeStatus,
-                _showRobinBuildingStatusIcon
+                _showRobinBuildingStatusIcon,
+                _showSeasonalBerry
             };
 
             int whichOption = 1;
@@ -116,6 +119,7 @@ namespace UIInfoSuite.Options
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(_options.ShowWhenNewRecipesAreAvailable)), whichOption++, _showQueenOfSauceIcon.ToggleOption, () => _options.ShowWhenNewRecipesAreAvailable, v => _options.ShowWhenNewRecipesAreAvailable = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(_options.ShowToolUpgradeStatus)), whichOption++, _showToolUpgradeStatus.ToggleOption, () => _options.ShowToolUpgradeStatus, v => _options.ShowToolUpgradeStatus = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(_options.ShowRobinBuildingStatusIcon)), whichOption++, _showRobinBuildingStatusIcon.ToggleOption, () => _options.ShowRobinBuildingStatusIcon, v => _options.ShowRobinBuildingStatusIcon = v));
+            _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(_options.ShowSeasonalBerry)), whichOption++, _showSeasonalBerry.ToggleOption, () => _options.ShowSeasonalBerry, v => _options.ShowSeasonalBerry = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(_options.ShowTodaysGifts)), whichOption++, _showTodaysGift.ToggleOption, () => _options.ShowTodaysGifts, v => _options.ShowTodaysGifts = v));
         }
 

--- a/UIInfoSuite2/UIElements/ShowSeasonalBerry.cs
+++ b/UIInfoSuite2/UIElements/ShowSeasonalBerry.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley;
+using StardewValley.Menus;
+using System;
+using Microsoft.Xna.Framework.Graphics;
+using UIInfoSuite.Infrastructure;
+using UIInfoSuite.Infrastructure.Extensions;
+using StardewValley.Buildings;
+using StardewModdingAPI.Utilities;
+
+namespace UIInfoSuite.UIElements
+{
+    class ShowSeasonalBerry : IDisposable
+    {
+        #region Properties
+
+        Rectangle? _berrySpriteLocation;
+        private float _spriteScale = 8 / 3f;
+        private string _hoverText;
+        private ClickableTextureComponent _berryIcon;
+
+        private readonly IModHelper _helper;
+
+        #endregion
+
+        #region Lifecycle
+
+        public ShowSeasonalBerry(IModHelper helper)
+        {
+            _helper = helper;
+        }
+
+        public void Dispose()
+        {
+            ToggleOption(false);
+        }
+
+        public void ToggleOption(bool showSeasonalBerry)
+        {
+            _berrySpriteLocation = null;
+            _helper.Events.GameLoop.DayStarted -= OnDayStarted;
+            _helper.Events.Display.RenderingHud -= OnRenderingHud;
+            _helper.Events.Display.RenderedHud -= OnRenderedHud;
+
+            if (showSeasonalBerry)
+            {
+                UpdateBerryForDay();
+
+                _helper.Events.GameLoop.DayStarted += OnDayStarted;
+                _helper.Events.Display.RenderingHud += OnRenderingHud;
+                _helper.Events.Display.RenderedHud += OnRenderedHud;
+            }
+        }
+
+        #endregion
+
+        #region Event subscriptions
+
+        private void OnDayStarted(object sender, DayStartedEventArgs e)
+        {
+            UpdateBerryForDay();
+        }
+
+        private void OnRenderingHud(object sender, RenderingHudEventArgs e)
+        {
+            // Draw icon
+            if (Game1.eventUp || !_berrySpriteLocation.HasValue) return;
+
+            var iconPosition = IconHandler.Handler.GetNewIconPosition();
+            _berryIcon =
+                new ClickableTextureComponent(
+                    new Rectangle(iconPosition.X, iconPosition.Y, 40, 40),
+                    Game1.objectSpriteSheet,
+                    _berrySpriteLocation.Value,
+                    _spriteScale
+                );
+            _berryIcon.draw(Game1.spriteBatch);
+        }
+
+        private void OnRenderedHud(object sender, RenderedHudEventArgs e)
+        {
+            // Show text on hover
+            var hasMouse = _berryIcon?.containsPoint(Game1.getMouseX(), Game1.getMouseY()) ?? false;
+            var hasText = !string.IsNullOrEmpty(_hoverText);
+            if (_berrySpriteLocation.HasValue && hasMouse && hasText)
+            {
+                IClickableMenu.drawHoverText(
+                    Game1.spriteBatch,
+                    _hoverText,
+                    Game1.dialogueFont
+                );
+            }
+        }
+
+        #endregion
+
+        #region Logic
+
+        private void UpdateBerryForDay()
+        {
+            var season = Game1.currentSeason;
+            var day = Game1.dayOfMonth;
+            switch (season)
+            {
+                case "spring" when day is >= 15 and <= 18:
+                    _berrySpriteLocation = new Rectangle(128, 193, 15, 15);
+                    _hoverText = _helper.SafeGetString(LanguageKeys.CanFindSalmonberry);
+                    _spriteScale = 8 / 3f;
+                    break;
+                case "fall" when day is >= 8 and <= 11:
+                    _berrySpriteLocation = new Rectangle(32, 272, 16, 16);
+                    _hoverText = _helper.SafeGetString(LanguageKeys.CanFindBlackberry);
+                    _spriteScale = 5 / 2f;
+                    break;
+                case "fall" when day >= 14:
+                    _berrySpriteLocation = new Rectangle(1, 274, 14, 14);
+                    _hoverText = _helper.SafeGetString(LanguageKeys.CanFindHazelnut);
+                    _spriteScale = 20 / 7f;
+                    break;
+                default:
+                    _berrySpriteLocation = null;
+                    break;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/UIInfoSuite2/i18n/default.json
+++ b/UIInfoSuite2/i18n/default.json
@@ -21,6 +21,10 @@
   "ToolIsFinishedBeingUpgraded": "{0} is finished!",
   "NpcBirthday": "{0}'s birthday",
   "RobinBuildingStatus": "Robin will finish your new building in {0} day(s)",
+  // Display icons - Foragables
+  "CanFindSalmonberry": "You can find Salmonberries today",
+  "CanFindBlackberry": "You can find Blackberries today",
+  "CanFindHazelnut": "You can find Hazelnuts on trees today",
   //Display icons - Luck
   "DailyLuckValue": "Your daily luck is {0}",
   "FeelingLucky": "You're feelin' lucky!!",
@@ -60,6 +64,7 @@
   "ShowRobinBuildingStatusIcon": "Show Robin building status",
   "ShowLuckIcon": "Show luck icon",
   "ShowExactValue": "Show exact value",
+  "ShowSeasonalBerry": "Show bush/tree forageables",
   //Others
   "LevelUp": "Level Up"
 }


### PR DESCRIPTION
This PR adds an option to show seasonal forgeable icons for when they're available.

- Added icons to show seasonal berries when available.
- Added option key and base lang keys.

Fixes #82 