### PR TITLE
Label wild seeds correctly

### DIFF
--- a/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
+++ b/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
@@ -248,11 +248,12 @@ namespace UIInfoSuite.UIElements
 
                         if (hoeDirt.crop.indexOfHarvest.Value > 0)
                         {
-                            string hoverText = _indexOfCropNames.SafeGet(hoeDirt.crop.indexOfHarvest.Value);
+                            int itemId = hoeDirt.crop.isWildSeedCrop() ? hoeDirt.crop.whichForageCrop.Value : hoeDirt.crop.indexOfHarvest.Value;
+                            string hoverText = _indexOfCropNames.SafeGet(itemId);
                             if (string.IsNullOrEmpty(hoverText))
                             {
-                                hoverText = new StardewValley.Object(new Debris(hoeDirt.crop.indexOfHarvest.Value, Vector2.Zero, Vector2.Zero).chunkType.Value, 1).DisplayName;
-                                _indexOfCropNames.Add(hoeDirt.crop.indexOfHarvest.Value, hoverText);
+                                hoverText = new StardewValley.Object(itemId, 1).DisplayName;
+                                _indexOfCropNames.Add(itemId, hoverText);
                             }
 
                             StringBuilder finalHoverText = new StringBuilder();


### PR DESCRIPTION
ie. display "Spring Seeds" instead of "Wild Horseradish",
"Fall Seeds" instead of "Common Mushroom" etc...

Fixes GitHub issue #130