### PR TITLE
Warn if Generic Mod Config Menu is older than 1.6.0

### DIFF
--- a/UIInfoSuite2/ModEntry.cs
+++ b/UIInfoSuite2/ModEntry.cs
@@ -109,6 +109,13 @@ namespace UIInfoSuite
         private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
         {
             // get Generic Mod Config Menu's API (if it's installed)
+            var modVersion = Helper.ModRegistry.Get("spacechase0.GenericModConfigMenu")?.Manifest?.Version;
+            var minModVersion = "1.6.0";
+            if (modVersion?.IsOlderThan(minModVersion) == true) {
+                Monitor.Log($"Detected Generic Mod Config Menu {modVersion} but expected {minModVersion} or newer. Disabling integration with that mod.", LogLevel.Warn);
+                return;
+            }
+
             var configMenu = Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
             if (configMenu is null)
                 return;


### PR DESCRIPTION
This avoids an exception from ModRegistry.GetApi().

The logic is copied from the TimeSpeed mod.

See GitHub issue #202