### PR TITLE
[Feature] Hovering over cooking recipe in cooking menu shows if player has not yet cooked recipe

### DIFF
--- a/UIInfoSuite2/Infrastructure/Tools.cs
+++ b/UIInfoSuite2/Infrastructure/Tools.cs
@@ -115,6 +115,19 @@ namespace UIInfoSuite2.Infrastructure
             return hoverItem;
         }
 
+        public static CraftingRecipe GetHoveredCraftingRecipe()
+        {
+            CraftingRecipe hoverRecipe = null;
+
+            if(Game1.activeClickableMenu is CraftingPage craftingPage)
+            {
+                FieldInfo hoveredCraftingRecipeField = typeof(CraftingPage).GetField("hoverRecipe", BindingFlags.Instance | BindingFlags.NonPublic);
+                hoverRecipe = hoveredCraftingRecipeField.GetValue(craftingPage) as CraftingRecipe;
+            }
+
+            return hoverRecipe;
+        }
+
         public static void GetSubTexture(Color[] output, Color[] originalColors, Rectangle sourceBounds, Rectangle clipArea)
         {
             if (output.Length < clipArea.Width * clipArea.Height)

--- a/UIInfoSuite2/Options/ModOptionsPageHandler.cs
+++ b/UIInfoSuite2/Options/ModOptionsPageHandler.cs
@@ -92,7 +92,7 @@ namespace UIInfoSuite2.Options
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.DisplayCalendarAndBillboard)), whichOption++, showCalendarAndBillboardOnGameMenuButton.ToggleOption, () => options.DisplayCalendarAndBillboard, v => options.DisplayCalendarAndBillboard = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowCropAndBarrelTooltip)), whichOption++, showCropAndBarrelTime.ToggleOption, () => options.ShowCropAndBarrelTooltip, v => options.ShowCropAndBarrelTooltip = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowItemEffectRanges)), whichOption++, showScarecrowAndSprinklerRange.ToggleOption, () => options.ShowItemEffectRanges, v => options.ShowItemEffectRanges = v));
-            _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowExtraItemInformation)), whichOption++, toggleHoverStuff, () => options.ShowExtraItemInformation, v => options.ShowExtraItemInformation = v));
+            _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowExtraItemInformation)), whichOption++, toggleHoverInformation, () => options.ShowExtraItemInformation, v => options.ShowExtraItemInformation = v));
             var travellingMerchantIcon = new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowTravelingMerchant)), whichOption++, showTravelingMerchant.ToggleOption, () => options.ShowTravelingMerchant, v => options.ShowTravelingMerchant = v);
             _optionsElements.Add(travellingMerchantIcon);
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.HideMerchantWhenVisited)), whichOption++, showTravelingMerchant.ToggleHideWhenVisitedOption, () => options.HideMerchantWhenVisited, v => options.HideMerchantWhenVisited = v, travellingMerchantIcon));
@@ -107,7 +107,7 @@ namespace UIInfoSuite2.Options
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowTodaysGifts)), whichOption++, showTodaysGift.ToggleOption, () => options.ShowTodaysGifts, v => options.ShowTodaysGifts = v));
         
         
-            void toggleHoverStuff(bool isChecked)
+            void toggleHoverInformation(bool isChecked)
             {
                 showHoverCraftableInCollection.ToggleOption(isChecked);
                 showItemHoverInformation.ToggleOption(isChecked);

--- a/UIInfoSuite2/Options/ModOptionsPageHandler.cs
+++ b/UIInfoSuite2/Options/ModOptionsPageHandler.cs
@@ -38,6 +38,7 @@ namespace UIInfoSuite2.Options
             var showScarecrowAndSprinklerRange = new ShowItemEffectRanges(helper);
             var experienceBar = new ExperienceBar(helper);
             var showItemHoverInformation = new ShowItemHoverInformation(helper);
+            var showHoverCraftableInCollection = new ShowHoverCraftableInCollection(helper);
             var shopHarvestPrices = new ShopHarvestPrices(helper);
             var showQueenOfSauceIcon = new ShowQueenOfSauceIcon(helper);
             var showTravelingMerchant = new ShowTravelingMerchant(helper);
@@ -91,7 +92,7 @@ namespace UIInfoSuite2.Options
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.DisplayCalendarAndBillboard)), whichOption++, showCalendarAndBillboardOnGameMenuButton.ToggleOption, () => options.DisplayCalendarAndBillboard, v => options.DisplayCalendarAndBillboard = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowCropAndBarrelTooltip)), whichOption++, showCropAndBarrelTime.ToggleOption, () => options.ShowCropAndBarrelTooltip, v => options.ShowCropAndBarrelTooltip = v));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowItemEffectRanges)), whichOption++, showScarecrowAndSprinklerRange.ToggleOption, () => options.ShowItemEffectRanges, v => options.ShowItemEffectRanges = v));
-            _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowExtraItemInformation)), whichOption++, showItemHoverInformation.ToggleOption, () => options.ShowExtraItemInformation, v => options.ShowExtraItemInformation = v));
+            _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowExtraItemInformation)), whichOption++, toggleHoverStuff, () => options.ShowExtraItemInformation, v => options.ShowExtraItemInformation = v));
             var travellingMerchantIcon = new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowTravelingMerchant)), whichOption++, showTravelingMerchant.ToggleOption, () => options.ShowTravelingMerchant, v => options.ShowTravelingMerchant = v);
             _optionsElements.Add(travellingMerchantIcon);
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.HideMerchantWhenVisited)), whichOption++, showTravelingMerchant.ToggleHideWhenVisitedOption, () => options.HideMerchantWhenVisited, v => options.HideMerchantWhenVisited = v, travellingMerchantIcon));
@@ -104,6 +105,14 @@ namespace UIInfoSuite2.Options
             _optionsElements.Add(seasonalBerryIcon);
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowSeasonalBerryHazelnut)), whichOption++, showSeasonalBerry.ToggleHazelnutOption, () => options.ShowSeasonalBerryHazelnut, v => options.ShowSeasonalBerryHazelnut = v, seasonalBerryIcon));
             _optionsElements.Add(new ModOptionsCheckbox(_helper.SafeGetString(nameof(options.ShowTodaysGifts)), whichOption++, showTodaysGift.ToggleOption, () => options.ShowTodaysGifts, v => options.ShowTodaysGifts = v));
+        
+        
+            void toggleHoverStuff(bool isChecked)
+            {
+                showHoverCraftableInCollection.ToggleOption(isChecked);
+                showItemHoverInformation.ToggleOption(isChecked);
+            }
+
         }
 
 

--- a/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
+++ b/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
@@ -1,0 +1,65 @@
+﻿using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UIInfoSuite2.Infrastructure;
+
+namespace UIInfoSuite2.UIElements
+{
+    internal class ShowHoverCraftableInCollection : IDisposable
+    {
+
+        private readonly IModHelper _helper;
+        private readonly PerScreen<CraftingRecipe> _hoverRecipe = new();
+
+        public ShowHoverCraftableInCollection(IModHelper helper)
+        {
+            _helper = helper;
+        }
+
+        public void ToggleOption(bool showItemHoverInformation)
+        {
+            //_helper.Events.Display.MenuChanged -= OnMenuChanged;
+            _helper.Events.Display.Rendering -= OnRendering;
+            _helper.Events.Display.Rendered -= OnRendered;
+
+
+            if (showItemHoverInformation)
+            {
+                //_helper.Events.Display.MenuChanged += OnMenuChanged;
+                _helper.Events.Display.Rendering += OnRendering;
+                _helper.Events.Display.Rendered += OnRendered;
+            }
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnRendering(object sender, EventArgs e)
+        {
+            _hoverRecipe.Value = Tools.GetHoveredCraftingRecipe();
+        }
+
+        private void OnRendered(object sender, EventArgs e)
+        {
+            if(Game1.activeClickableMenu != null)
+            {
+                if(_hoverRecipe.Value != null)
+                {
+                    var recipe = _hoverRecipe.Value;
+                    if (recipe.isCookingRecipe && Game1.player.recipesCooked.Keys.Contains(recipe.getIndexOfMenuView()))
+                    {
+                        ModEntry.MonitorObject.Log($"Player has cooked {recipe.name}", LogLevel.Debug);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
+++ b/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
@@ -1,14 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using StardewModdingAPI;
-using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UIInfoSuite2.Infrastructure;
 
 namespace UIInfoSuite2.UIElements
@@ -24,26 +19,14 @@ namespace UIInfoSuite2.UIElements
             _helper = helper;
         }
 
-        private readonly ClickableTextureComponent _shippingTopIcon =
-            new(
-                "",
-                new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
-                "",
-                "",
-                Game1.mouseCursors,
-                new Rectangle(134, 236, 30, 15),
-                Game1.pixelZoom);
-
         public void ToggleOption(bool showItemHoverInformation)
         {
-            //_helper.Events.Display.MenuChanged -= OnMenuChanged;
             _helper.Events.Display.Rendering -= OnRendering;
             _helper.Events.Display.Rendered -= OnRendered;
 
 
             if (showItemHoverInformation)
             {
-                //_helper.Events.Display.MenuChanged += OnMenuChanged;
                 _helper.Events.Display.Rendering += OnRendering;
                 _helper.Events.Display.Rendered += OnRendered;
             }
@@ -72,8 +55,6 @@ namespace UIInfoSuite2.UIElements
                 {
                     if (recipe.isCookingRecipe && !Game1.player.recipesCooked.ContainsKey(recipe.getIndexOfMenuView()))
                     {
-                        ModEntry.MonitorObject.Log($"Player has not cooked {recipe.name}", LogLevel.Debug);
-
                         int windowHeight = 80;
 
                         int windowY = Game1.getMouseY() + 20;
@@ -93,14 +74,10 @@ namespace UIInfoSuite2.UIElements
                         }
 
                         Vector2 windowPos = new Vector2(windowX, windowY);
-
-                        int num1 = (int)windowPos.X + 22;
+                        
+                        // +22 centers the image in the box
+                        int num1 = (int)windowPos.X + 22; 
                         int num2 = (int)windowPos.Y + 22;
-
-                        //_shippingTopIcon.bounds.X = num1;
-                        //_shippingTopIcon.bounds.Y = num2;
-                        //_shippingTopIcon.scale = 1.2f;
-                        //_shippingTopIcon.draw(Game1.spriteBatch)
 
                         IClickableMenu.drawTextureBox(
                             Game1.spriteBatch,
@@ -111,7 +88,6 @@ namespace UIInfoSuite2.UIElements
                             windowWidth,
                             windowHeight,
                             Color.White);
-
 
                         var _icon = new ClickableTextureComponent(
                             new Rectangle(num1, num2, 40, 40),

--- a/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
+++ b/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
@@ -1,7 +1,9 @@
-﻿using StardewModdingAPI;
+﻿using Microsoft.Xna.Framework;
+using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
+using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +23,16 @@ namespace UIInfoSuite2.UIElements
         {
             _helper = helper;
         }
+
+        private readonly ClickableTextureComponent _shippingTopIcon =
+            new(
+                "",
+                new Rectangle(0, 0, Game1.tileSize, Game1.tileSize),
+                "",
+                "",
+                Game1.mouseCursors,
+                new Rectangle(134, 236, 30, 15),
+                Game1.pixelZoom);
 
         public void ToggleOption(bool showItemHoverInformation)
         {
@@ -49,13 +61,65 @@ namespace UIInfoSuite2.UIElements
 
         private void OnRendered(object sender, EventArgs e)
         {
-            if(Game1.activeClickableMenu != null)
+            DrawToolTip();
+        }
+
+        private void DrawToolTip()
+        {
+            if (Game1.activeClickableMenu != null)
             {
-                if(_hoverRecipe.Value is StardewValley.CraftingRecipe recipe)
+                if (_hoverRecipe.Value is StardewValley.CraftingRecipe recipe)
                 {
-                    if (recipe.isCookingRecipe && Game1.player.recipesCooked.ContainsKey(recipe.getIndexOfMenuView()))
+                    if (recipe.isCookingRecipe && !Game1.player.recipesCooked.ContainsKey(recipe.getIndexOfMenuView()))
                     {
-                        ModEntry.MonitorObject.Log($"Player has cooked {recipe.name}", LogLevel.Debug);
+                        ModEntry.MonitorObject.Log($"Player has not cooked {recipe.name}", LogLevel.Debug);
+
+                        int windowHeight = 80;
+
+                        int windowY = Game1.getMouseY() + 20;
+                        windowY = Game1.viewport.Height - windowHeight - windowY < 0 ? Game1.viewport.Height - windowHeight : windowY;
+
+                        int windowWidth = 80;
+
+                        int windowX = Game1.getMouseX() - windowWidth - 25;
+
+                        if (Game1.getMouseX() > Game1.viewport.Width - 300)
+                        {
+                            windowX = Game1.viewport.Width - windowWidth - 350;
+                        }
+                        else if (windowX < 0)
+                        {
+                            windowX = Game1.getMouseX() + 350;
+                        }
+
+                        Vector2 windowPos = new Vector2(windowX, windowY);
+
+                        int num1 = (int)windowPos.X + 22;
+                        int num2 = (int)windowPos.Y + 22;
+
+                        //_shippingTopIcon.bounds.X = num1;
+                        //_shippingTopIcon.bounds.Y = num2;
+                        //_shippingTopIcon.scale = 1.2f;
+                        //_shippingTopIcon.draw(Game1.spriteBatch)
+
+                        IClickableMenu.drawTextureBox(
+                            Game1.spriteBatch,
+                            Game1.menuTexture,
+                            new Rectangle(0, 256, 60, 60),
+                            (int)windowPos.X,
+                            (int)windowPos.Y,
+                            windowWidth,
+                            windowHeight,
+                            Color.White);
+
+
+                        var _icon = new ClickableTextureComponent(
+                            new Rectangle(num1, num2, 40, 40),
+                            Game1.mouseCursors,
+                            new Rectangle(609, 361, 28, 28),
+                            1.3f);
+
+                        _icon.draw(Game1.spriteBatch);
                     }
                 }
             }

--- a/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
+++ b/UIInfoSuite2/UIElements/ShowHoverCraftableInCollection.cs
@@ -51,10 +51,9 @@ namespace UIInfoSuite2.UIElements
         {
             if(Game1.activeClickableMenu != null)
             {
-                if(_hoverRecipe.Value != null)
+                if(_hoverRecipe.Value is StardewValley.CraftingRecipe recipe)
                 {
-                    var recipe = _hoverRecipe.Value;
-                    if (recipe.isCookingRecipe && Game1.player.recipesCooked.Keys.Contains(recipe.getIndexOfMenuView()))
+                    if (recipe.isCookingRecipe && Game1.player.recipesCooked.ContainsKey(recipe.getIndexOfMenuView()))
                     {
                         ModEntry.MonitorObject.Log($"Player has cooked {recipe.name}", LogLevel.Debug);
                     }


### PR DESCRIPTION
Related issue: #224 

## Problem

Currently, when trying to complete the Master Chef achievement, one must first check the collections menu in order to see if a recipe they have the ingredients for has already been cooked and added to the collection. Sometimes they can make a mistake and spend precious ingredients on a recipe they have already made! Frustrating.

## Solution

I have added a `TextureBox` that appears next to the cursor when hovering over a cooking recipe (only unlocked recipes, of course) that simply displays our beloved Queen of Sauce if the player has not yet cooked it. This takes out all of the back and forth checking between menus. 

## PSA

This was my first time ever trying something in the SV modding world as well as in the C# world.
**Please let me know if there are any revisions you would like me to make!** 😄 

## Screenshots

(Please excuse my other active mods)

![Screenshot 2022-07-25 233426](https://user-images.githubusercontent.com/17889018/180918514-40f19176-428c-438a-8ad9-73b0ef037119.png)

Player has not yet cooked the Pink Cake, so Queen of Sauce is displayed.

![Screenshot 2022-07-25 233447](https://user-images.githubusercontent.com/17889018/180918516-672164a7-7a61-4271-9918-95a0c9e94c42.png)

Player _has_ cooked the Fried Calamari, so Queen of Sauce is _not_ displayed.

