### PR TITLE
Version 2.2.9

### DIFF
--- a/UIInfoSuite2/UIElements/LuckOfDay.cs
+++ b/UIInfoSuite2/UIElements/LuckOfDay.cs
@@ -28,6 +28,7 @@ namespace UIInfoSuite2.UIElements
                 false));
         private readonly IModHelper _helper;
 
+        private bool Enabled { get; set; }
         private bool ShowExactValue { get; set; }
 
         private static readonly Color Luck1Color = new(87, 255, 106, 255);
@@ -51,6 +52,8 @@ namespace UIInfoSuite2.UIElements
 
         public void ToggleOption(bool showLuckOfDay)
         {
+            Enabled = showLuckOfDay;
+
             _helper.Events.Player.Warped -= OnWarped;
             _helper.Events.Display.RenderingHud -= OnRenderingHud;
             _helper.Events.Display.RenderedHud -= OnRenderedHud;
@@ -68,7 +71,7 @@ namespace UIInfoSuite2.UIElements
         public void ToggleShowExactValueOption(bool showExactValue)
         {
             ShowExactValue = showExactValue;
-            ToggleOption(true);
+            ToggleOption(Enabled);
         }
         #endregion
 

--- a/UIInfoSuite2/UIElements/ShowBirthdayIcon.cs
+++ b/UIInfoSuite2/UIElements/ShowBirthdayIcon.cs
@@ -17,7 +17,9 @@ namespace UIInfoSuite2.UIElements
         #region Properties
         private readonly PerScreen<List<NPC>> _birthdayNPCs = new(() => new());
         private readonly PerScreen<List<ClickableTextureComponent>> _birthdayIcons = new(() => new());
-        public bool HideBirthdayIfFullFriendShip { get; set; }
+
+        private bool Enabled { get; set; }
+        private bool HideBirthdayIfFullFriendShip { get; set; }
         private readonly IModHelper _helper;
         #endregion
 
@@ -35,6 +37,8 @@ namespace UIInfoSuite2.UIElements
 
         public void ToggleOption(bool showBirthdayIcon)
         {
+            Enabled = showBirthdayIcon;
+
             _helper.Events.GameLoop.DayStarted -= OnDayStarted;
             _helper.Events.Display.RenderingHud -= OnRenderingHud;
             _helper.Events.Display.RenderedHud -= OnRenderedHud;
@@ -53,7 +57,7 @@ namespace UIInfoSuite2.UIElements
         public void ToggleDisableOnMaxFriendshipOption(bool hideBirthdayIfFullFriendShip)
         {
             HideBirthdayIfFullFriendShip = hideBirthdayIfFullFriendShip;
-            ToggleOption(true);
+            ToggleOption(Enabled);
         }
 
         #endregion

--- a/UIInfoSuite2/UIElements/ShowCalendarAndBillboardOnGameMenuButton.cs
+++ b/UIInfoSuite2/UIElements/ShowCalendarAndBillboardOnGameMenuButton.cs
@@ -105,6 +105,10 @@ namespace UIInfoSuite2.UIElements
 
             _showBillboardButton.Value = billboardButton;
             _showBillboardButton.Value.draw(Game1.spriteBatch);
+
+            // Draw the mouse again to display it over the billboard
+            Game1.activeClickableMenu.drawMouse(Game1.spriteBatch);
+
             if (_showBillboardButton.Value.containsPoint(Game1.getMouseX(), Game1.getMouseY()))
             {
                 string hoverText = Game1.getMouseX() <

--- a/UIInfoSuite2/UIElements/ShowRobinBuildingStatusIcon.cs
+++ b/UIInfoSuite2/UIElements/ShowRobinBuildingStatusIcon.cs
@@ -123,6 +123,10 @@ namespace UIInfoSuite2.UIElements
                 if (_robinIconSheet != null)
                     break;
             }
+            if (_robinIconSheet == null)
+            {
+                ModEntry.MonitorObject.Log($"{this.GetType().Name}: Could not find Robin spritesheet.", LogLevel.Warn);
+            }
 
             _buildingIconSpriteLocation = new Rectangle(0, 195 + 1, 15, 15 - 1);    // 1px edits for better alignment with other icons
         }

--- a/UIInfoSuite2/UIElements/ShowSeasonalBerry.cs
+++ b/UIInfoSuite2/UIElements/ShowSeasonalBerry.cs
@@ -19,7 +19,9 @@ namespace UIInfoSuite2.UIElements
         private ClickableTextureComponent _berryIcon;
 
         private readonly IModHelper _helper;
-        public bool ShowHazelnut { get; set; }
+
+        private bool Enabled { get; set; }
+        private bool ShowHazelnut { get; set; }
 
         #endregion
 
@@ -37,6 +39,8 @@ namespace UIInfoSuite2.UIElements
 
         public void ToggleOption(bool showSeasonalBerry)
         {
+            Enabled = showSeasonalBerry;
+
             _berrySpriteLocation = null;
             _helper.Events.GameLoop.DayStarted -= OnDayStarted;
             _helper.Events.Display.RenderingHud -= OnRenderingHud;
@@ -55,7 +59,7 @@ namespace UIInfoSuite2.UIElements
         public void ToggleHazelnutOption(bool showHazelnut)
         {
             ShowHazelnut = showHazelnut;
-            ToggleOption(true);
+            ToggleOption(Enabled);
         }
 
         #endregion

--- a/UIInfoSuite2/UIElements/ShowTravelingMerchant.cs
+++ b/UIInfoSuite2/UIElements/ShowTravelingMerchant.cs
@@ -18,7 +18,8 @@ namespace UIInfoSuite2.UIElements
         private bool _travelingMerchantIsVisited;
         private ClickableTextureComponent _travelingMerchantIcon;
 
-        public bool HideWhenVisited { get; set; }
+        private bool Enabled { get; set; }
+        private bool HideWhenVisited { get; set; }
 
         private readonly IModHelper _helper;
         #endregion
@@ -37,6 +38,8 @@ namespace UIInfoSuite2.UIElements
 
         public void ToggleOption(bool showTravelingMerchant)
         {
+            Enabled = showTravelingMerchant;
+
             _helper.Events.Display.RenderingHud -= OnRenderingHud;
             _helper.Events.Display.RenderedHud -= OnRenderedHud;
             _helper.Events.GameLoop.DayStarted -= OnDayStarted;
@@ -55,7 +58,7 @@ namespace UIInfoSuite2.UIElements
         public void ToggleHideWhenVisitedOption(bool hideWhenVisited)
         {
             HideWhenVisited = hideWhenVisited;
-            ToggleOption(true);
+            ToggleOption(Enabled);
         }
         #endregion
 

--- a/UIInfoSuite2/UIElements/ShowWhenAnimalNeedsPet.cs
+++ b/UIInfoSuite2/UIElements/ShowWhenAnimalNeedsPet.cs
@@ -19,7 +19,8 @@ namespace UIInfoSuite2.UIElements
         private readonly PerScreen<float> _yMovementPerDraw = new();
         private readonly PerScreen<float> _alpha = new();
 
-        public bool HideOnMaxFriendship { get; set; }
+        private bool Enabled { get; set; }
+        private bool HideOnMaxFriendship { get; set; }
 
         private readonly IModHelper _helper;
         #endregion
@@ -38,6 +39,8 @@ namespace UIInfoSuite2.UIElements
 
         public void ToggleOption(bool showWhenAnimalNeedsPet)
         {
+            Enabled = showWhenAnimalNeedsPet;
+
             _helper.Events.Player.Warped -= OnWarped;
             _helper.Events.Display.RenderingHud -= OnRenderingHud_DrawAnimalHasProduct;
             _helper.Events.Display.RenderingHud -= OnRenderingHud_DrawNeedsPetTooltip;
@@ -54,7 +57,7 @@ namespace UIInfoSuite2.UIElements
         public void ToggleDisableOnMaxFriendshipOption(bool hideOnMaxFriendship)
         {
             HideOnMaxFriendship = hideOnMaxFriendship;
-            ToggleOption(true);
+            ToggleOption(Enabled);
         }
         #endregion
 

--- a/UIInfoSuite2/UIInfoSuite2.csproj
+++ b/UIInfoSuite2/UIInfoSuite2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.8</Version>
+    <Version>2.2.9</Version>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 

--- a/UIInfoSuite2/UIInfoSuite2.csproj
+++ b/UIInfoSuite2/UIInfoSuite2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.2.7</Version>
+    <Version>2.2.8</Version>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 

--- a/UIInfoSuite2/manifest.json
+++ b/UIInfoSuite2/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "UI Info Suite 2",
     "Author": "Annosz",
-    "Version": "2.2.7",
+    "Version": "2.2.8",
     "Description": "Adds a useful information to the user interface. Based on Cdaragorn's excellent UI Info Suite.",
     "UniqueID": "Annosz.UiInfoSuite2",
     "EntryDll": "UIInfoSuite2.dll",

--- a/UIInfoSuite2/manifest.json
+++ b/UIInfoSuite2/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "UI Info Suite 2",
     "Author": "Annosz",
-    "Version": "2.2.8",
+    "Version": "2.2.9",
     "Description": "Adds a useful information to the user interface. Based on Cdaragorn's excellent UI Info Suite.",
     "UniqueID": "Annosz.UiInfoSuite2",
     "EntryDll": "UIInfoSuite2.dll",


### PR DESCRIPTION
- Temporary fix for secondary options enabling their parent options
- Add warning if Robin's spritesheet couldn't be found
- Fix mouse being drawn under the billboard in the menu