### PR TITLE
Fix for tooltip rendering behind menus

### DIFF
--- a/UIInfoSuite2/UIElements/ShowItemHoverInformation.cs
+++ b/UIInfoSuite2/UIElements/ShowItemHoverInformation.cs
@@ -81,7 +81,7 @@ namespace UIInfoSuite2.UIElements
     {
       _helper.Events.GameLoop.DayStarted -= OnDayStarted;
       _helper.Events.Player.InventoryChanged -= OnInventoryChanged;
-      _helper.Events.Display.Rendered -= OnRendered;
+      _helper.Events.Display.RenderedActiveMenu -= OnRendered;
       _helper.Events.Display.RenderedHud -= OnRenderedHud;
       _helper.Events.Display.Rendering -= OnRendering;
 
@@ -93,7 +93,7 @@ namespace UIInfoSuite2.UIElements
 
         _helper.Events.GameLoop.DayStarted += OnDayStarted;
         _helper.Events.Player.InventoryChanged += OnInventoryChanged;
-        _helper.Events.Display.Rendered += OnRendered;
+        _helper.Events.Display.RenderedActiveMenu += OnRendered;
         _helper.Events.Display.RenderedHud += OnRenderedHud;
         _helper.Events.Display.Rendering += OnRendering;
       }


### PR DESCRIPTION
Changed OnRendered to look for event RenderedActiveMenu from Rendered in ShowItemHoverInformation to resolve issues where the tooltip was drawn behind the menu.