### PR TITLE
fix: Move options tab to a non-overlapping position

### DIFF
--- a/UIInfoSuite2/Options/ModOptionsPageHandler.cs
+++ b/UIInfoSuite2/Options/ModOptionsPageHandler.cs
@@ -712,7 +712,7 @@ namespace UIInfoSuite2.Options
 
     private int GetButtonXPosition(GameMenu gameMenu)
     {
-      return gameMenu.xPositionOnScreen + gameMenu.width - 200;
+      return gameMenu.xPositionOnScreen + gameMenu.width - 120;
     }
 
     private void DrawButton(GameMenu gameMenu)


### PR DESCRIPTION
Move the options tab over a bit to account for the new tabs in the inventory menu
Fixes #371 