### PR TITLE
add missing german translations

### DIFF
--- a/UIInfoSuite2/i18n/de.json
+++ b/UIInfoSuite2/i18n/de.json
@@ -1,6 +1,6 @@
 {
   // GUI - Game Menu
-  // "OptionsTabTooltip": "UI Info Suite 2 Options", // TODO
+  "OptionsTabTooltip": "UI Info Suite 2 Optionen",
   //GUI - Billboard
   "Billboard": "Schwarzes Brett",
   "Calendar": "Kalender",
@@ -25,7 +25,7 @@
   "ToolIsFinishedBeingUpgraded": "{0} ist fertig!",
   "NpcBirthday": "{0}'s Geburtstag",
   "RobinBuildingStatus": "Robin wird in {0} Tage(n) mit dem Bau fertig sein",
-  "RobinHouseUpgradeStatus": "Robin will finish upgrading your house in {0} day(s)", // TODO
+  "RobinHouseUpgradeStatus": "Robin wird in {0} Tage(n) mit der Hauserweiterung fertig sein",
   // Display icons - Foragables
   "CanFindSalmonberry": "Du kannst heute Lachsbeeren finden",
   "CanFindBlackberry": "Du kannst heute Brombeeren finden",


### PR DESCRIPTION
adds missing german translations for "OptionsTabTooltip" and "RobinHouseUpgradeStatus"