### PR TITLE
added missing french translation and fixed inconsistency

### DIFF
--- a/UIInfoSuite2/i18n/de.json
+++ b/UIInfoSuite2/i18n/de.json
@@ -21,7 +21,7 @@
   "SnowNextDay": "Es wird morgen schneien",
   "IslandRainNextDay": "Es wird morgen regnen",
   "IslandThunderstormNextDay": "Es wird morgen ein Gewitter geben",
-  "DaysUntilToolIsUpgraded": "{0} Tage bis {1} fertig verbessert wurde",
+  "DaysUntilToolIsUpgraded": "{0} Tag(e) bis {1} fertig verbessert wurde",
   "ToolIsFinishedBeingUpgraded": "{0} ist fertig!",
   "NpcBirthday": "{0}'s Geburtstag",
   "RobinBuildingStatus": "Robin wird in {0} Tage(n) mit dem Bau fertig sein",

--- a/UIInfoSuite2/i18n/default.json
+++ b/UIInfoSuite2/i18n/default.json
@@ -21,7 +21,7 @@
   "SnowNextDay": "There will be snow tomorrow",
   "IslandRainNextDay": "There will be rain on the island tomorrow",
   "IslandThunderstormNextDay": "There will be a thunderstorm on the island tomorrow",
-  "DaysUntilToolIsUpgraded": "{0} days until {1} is finished being upgraded",
+  "DaysUntilToolIsUpgraded": "{0} day(s) until {1} is finished being upgraded",
   "ToolIsFinishedBeingUpgraded": "{0} is finished!",
   "NpcBirthday": "{0}'s birthday",
   "RobinBuildingStatus": "Robin will finish your new building in {0} day(s)",

--- a/UIInfoSuite2/i18n/es.json
+++ b/UIInfoSuite2/i18n/es.json
@@ -21,7 +21,7 @@
   "SnowNextDay": "Mañana nevará",
   "IslandRainNextDay": "Mañana lloverá",
   "IslandThunderstormNextDay": "Mañana habrá tormenta eléctrica",
-  "DaysUntilToolIsUpgraded": "{0} días hasta que {1} termine de actualizarse",
+  "DaysUntilToolIsUpgraded": "{0} día(s) hasta que {1} termine de actualizarse",
   "ToolIsFinishedBeingUpgraded": "¡{0} está terminado!",
   "NpcBirthday": "Cumpleaños de {0}",
   "RobinBuildingStatus": "Robin terminará tu nuevo edificio en {0} día(s)",

--- a/UIInfoSuite2/i18n/fr.json
+++ b/UIInfoSuite2/i18n/fr.json
@@ -25,7 +25,7 @@
   "ToolIsFinishedBeingUpgraded": "{0} est terminé!",
   "NpcBirthday": "Anniversaire de {0}",
   "RobinBuildingStatus": "Robin aura fini votre nouveau batiment dans {0} jour(s)",
-  "RobinHouseUpgradeStatus": "Robin will finish upgrading your house in {0} day(s)", // TODO
+  "RobinHouseUpgradeStatus": "Robin aura fini d'améliorer ta maison dans {0} jour(s)",
   // Display icons - Foragables
   "CanFindSalmonberry": "Vous pouvez trouver des baies rouges aujourd'hui",
   "CanFindBlackberry": "Vous pouvez trouver des baies noires aujourd'hui",

--- a/UIInfoSuite2/i18n/fr.json
+++ b/UIInfoSuite2/i18n/fr.json
@@ -21,7 +21,7 @@
   "SnowNextDay": "Il va neiger demain",
   "IslandRainNextDay": "Il va pleuvoir demain",
   "IslandThunderstormNextDay": "Il va y avoir un orage demain",
-  "DaysUntilToolIsUpgraded": "{0} jours avant que {1} ne termine de s'améliorer",
+  "DaysUntilToolIsUpgraded": "{0} jour(s) avant que {1} ne termine de s'améliorer",
   "ToolIsFinishedBeingUpgraded": "{0} est terminé!",
   "NpcBirthday": "Anniversaire de {0}",
   "RobinBuildingStatus": "Robin aura fini votre nouveau batiment dans {0} jour(s)",

--- a/UIInfoSuite2/i18n/it.json
+++ b/UIInfoSuite2/i18n/it.json
@@ -21,7 +21,7 @@
   "SnowNextDay": "Domani nevicherà",
   "IslandRainNextDay": "Domani pioverà nell'isola",
   "IslandThunderstormNextDay": "Ci sarà un temporale domani nell'isola",
-  "DaysUntilToolIsUpgraded": "{0} giorni finchè {1} sarà migliorato",
+  "DaysUntilToolIsUpgraded": "{0} giorno(i) finchè {1} sarà migliorato",
   "ToolIsFinishedBeingUpgraded": "{0} è completo!",
   "NpcBirthday": "Compleanno di {0}",
   "RobinBuildingStatus": "Robin completerà il tuo nuovo edificio in {0} giorno(i)",


### PR DESCRIPTION
I added a missing french translation for "RobinHouseUpgradeStatus" 

I also noticed that "DaysUntilToolIsUpgraded" uses 'days' and is inconsitent with "RobinBuildingStatus" ('day(s)'). This can lead to slightly incorrect ingame messages. I fixed that for some languages (some already use the combined singular and plurar form).