### PR TITLE
Compatibility with multi fertilizer & fix NullReferenceException

### DIFF
--- a/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
+++ b/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
@@ -8,6 +8,7 @@ using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Buildings;
+using StardewValley.ItemTypeDefinitions;
 using StardewValley.Menus;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
@@ -332,7 +333,16 @@ internal class ShowCropAndBarrelTime : IDisposable
 
             if (!string.IsNullOrEmpty(hoeDirt.fertilizer.Value))
             {
-              string fertilizerName = ItemRegistry.GetData(hoeDirt.fertilizer.Value).DisplayName ?? "Unknown Fertilizer";
+              string fertilizerName = string.Join(
+                "/",
+                hoeDirt.fertilizer.Value.Split('|')
+                       .Select(
+                         x => {
+                           ParsedItemData? fertilizer = ItemRegistry.GetData(x);
+                           return fertilizer == null ? "Unknown Fertilizer" : fertilizer.DisplayName;
+                         }
+                       )
+              );
               string withText = _helper.SafeGetString(LanguageKeys.With);
               hoverText.Append($"\n({withText} {fertilizerName})");
             }
@@ -355,9 +365,17 @@ internal class ShowCropAndBarrelTime : IDisposable
             );
           }
         }
-        else if (!string.IsNullOrEmpty(hoeDirt.fertilizer.Value))
-        {
-          string fertilizerName = ItemRegistry.GetData(hoeDirt.fertilizer.Value).DisplayName ?? "Unknown Fertilizer";
+        else if (!string.IsNullOrEmpty(hoeDirt.fertilizer.Value)) {
+          string fertilizerName = string.Join(
+            "/",
+            hoeDirt.fertilizer.Value.Split('|')
+                   .Select(
+                     x => {
+                       ParsedItemData? fertilizer = ItemRegistry.GetData(x);
+                       return fertilizer == null ? "Unknown Fertilizer" : fertilizer.DisplayName;
+                     }
+                   )
+          );
           string hoverText = fertilizerName;
           IClickableMenu.drawHoverText(
             Game1.spriteBatch,


### PR DESCRIPTION
My mod allows players to apply multiple fertilizers to a single tile. I achieve this by storing multiple fertilizer IDs, separated by `|`, in a string. This patch enables UIInfoSuite to display multiple fertilizers. The method I've used also allows the vanilla way of 1 fertilizer per tile to still function.

This patch also fixes a potential NullReferenceException when `hoeDirt.fertilizer.Value` is an invalid ID.
```csharp
ItemRegistry.GetData(hoeDirt.fertilizer.Value).DisplayName ?? "Unknown Fertilizer"
```
The `??` operator checks if the previous value is null. However, it checks the string, not the `ParsedItemData`, this means `ItemRegistry.GetData(hoeDirt.fertilizer.Value).DisplayName` will be returned if it is not null. If it is null, then "Unknown Fertilizer" will be returned. But, if `ItemRegistry.GetData(hoeDirt.fertilizer.Value)` itself is null, trying to access the `DisplayName` property on it will result in a NullReferenceException.