### PR TITLE
Compatibility support for Deluxe Journal

### DIFF
--- a/UIInfoSuite2/Infrastructure/IconHandler.cs
+++ b/UIInfoSuite2/Infrastructure/IconHandler.cs
@@ -13,11 +13,13 @@ public sealed class IconHandler
 
   public static IconHandler Handler { get; } = new();
 
+  public bool IsQuestLogPermanent { get; set; } = false;
+
   public Point GetNewIconPosition()
   {
     int yPos = Game1.options.zoomButtons ? 290 : 260;
     int xPosition = Tools.GetWidthInPlayArea() - 70 - 48 * _amountOfVisibleIcons.Value;
-    if (Game1.player.questLog.Any() || Game1.player.team.specialOrders.Any())
+    if (IsQuestLogPermanent || Game1.player.questLog.Any() || Game1.player.team.specialOrders.Any())
     {
       xPosition -= 65;
     }

--- a/UIInfoSuite2/ModEntry.cs
+++ b/UIInfoSuite2/ModEntry.cs
@@ -27,6 +27,8 @@ public class ModEntry : Mod
     helper.Events.GameLoop.Saved += OnSaved;
     helper.Events.GameLoop.GameLaunched += OnGameLaunched;
     helper.Events.Display.Rendering += IconHandler.Handler.Reset;
+
+    IconHandler.Handler.IsQuestLogPermanent = helper.ModRegistry.IsLoaded("MolsonCAD.DeluxeJournal");
   }
 #endregion
 


### PR DESCRIPTION
Adds compatibility support for the Deluxe Journal mod. The journal/quest log button becomes a permanent feature and covers up the UI Info Suite icons (when they shift over after all quests are completed).

Rather than doing something silly, like adding an invisible dummy quest (lots of issues will spawn from this), it would make more sense to check if Deluxe Journal was loaded on the UI Info Suite-side.

Deluxe Journal Nexus page for reference: https://www.nexusmods.com/stardewvalley/mods/11436.
And the GitHub repo: https://github.com/MolsonCAD/DeluxeJournal.