### PR TITLE
Implementation of Issue 478 (EXP bar and pop ups work with mastery)

### DIFF
--- a/UIInfoSuite2/UIElements/ExperienceBar.cs
+++ b/UIInfoSuite2/UIElements/ExperienceBar.cs
@@ -6,6 +6,7 @@ using StardewModdingAPI.Events;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Tools;
+using StardewValley.Menus;
 using UIInfoSuite2.Compatibility;
 using UIInfoSuite2.Infrastructure;
 using UIInfoSuite2.Infrastructure.Extensions;
@@ -313,10 +314,26 @@ public partial class ExperienceBar
     _experienceFillColor.Value = ExperienceFillColor[(SkillType)currentLevelIndex];
     _currentSkillLevel.Value = Game1.player.GetUnmodifiedSkillLevel(currentLevelIndex);
 
-    _experienceRequiredToLevel.Value = GetExperienceRequiredToLevel(_currentSkillLevel.Value);
-    _experienceFromPreviousLevels.Value = GetExperienceRequiredToLevel(_currentSkillLevel.Value - 1);
-    _experienceEarnedThisLevel.Value =
-      Game1.player.experiencePoints[currentLevelIndex] - _experienceFromPreviousLevels.Value;
+    
+    if (Game1.player.Level >= 25 && (MasteryTrackerMenu.getCurrentMasteryLevel() < 5))
+    {
+      _experienceRequiredToLevel.Value = MasteryTrackerMenu.getMasteryExpNeededForLevel(MasteryTrackerMenu.getCurrentMasteryLevel() + 1);
+      _experienceFromPreviousLevels.Value = MasteryTrackerMenu.getMasteryExpNeededForLevel(MasteryTrackerMenu.getCurrentMasteryLevel());
+      _experienceEarnedThisLevel.Value = (int)Game1.stats.Get("MasteryExp") - MasteryTrackerMenu.getMasteryExpNeededForLevel(MasteryTrackerMenu.getCurrentMasteryLevel());
+      _currentMasteryXP.Value = (int)Game1.stats.Get("MasteryExp");
+
+      //TODO: I tried making this match the dark green from the mastery bar on the player menu but no matter what i did, it oversaturates and makes a bright color
+      _experienceFillColor.Value = new Color(0, 5, 0, 0.93f);
+      //TODO: Need to find a good icon to use for this (and also figure out how to implement that)
+      _experienceIconRectangle.Value = SkillIconRectangles[SkillType.Luck];
+      //TODO: text overflows the EXP bar
+    }
+    else
+    {
+      _experienceRequiredToLevel.Value = GetExperienceRequiredToLevel(_currentSkillLevel.Value);
+      _experienceFromPreviousLevels.Value = GetExperienceRequiredToLevel(_currentSkillLevel.Value - 1);
+      _experienceEarnedThisLevel.Value = Game1.player.experiencePoints[currentLevelIndex] - _experienceFromPreviousLevels.Value;
+    }
 
     if (_experienceRequiredToLevel.Value <= 0 && _levelExtenderApi != null)
     {
@@ -329,7 +346,7 @@ public partial class ExperienceBar
 
     if (displayExperience)
     {
-      if (ExperienceGainTextEnabled && _experienceRequiredToLevel.Value > 0 && Game1.player.Level < 25)
+      if (ExperienceGainTextEnabled && _experienceRequiredToLevel.Value > 0)
       {
         int currentExperienceToUse = Game1.player.experiencePoints[currentLevelIndex];
         int previousExperienceToUse = _currentExperience.Value[currentLevelIndex];
@@ -347,14 +364,6 @@ public partial class ExperienceBar
             new DisplayedExperienceValue(experienceGain, Game1.player.getLocalPosition(Game1.viewport))
           );
         }
-      }
-      else if(Game1.player.Level >= 25 && ((int)Game1.stats.Get("MasteryExp") < 100000))
-      {
-          int newMasteryXP = (int)Game1.stats.Get("MasteryExp") - _currentMasteryXP.Value;
-          _currentMasteryXP.Value = (int)Game1.stats.Get("MasteryExp");
-          _displayedExperienceValues.Value.Add(
-            new DisplayedExperienceValue(newMasteryXP, Game1.player.getLocalPosition(Game1.viewport))
-          );
       }
 
       _currentExperience.Value[currentLevelIndex] = Game1.player.experiencePoints[currentLevelIndex];
@@ -383,5 +392,5 @@ public partial class ExperienceBar
       _ => -1
     };
   }
-#endregion Logic
+  #endregion Logic
 }

--- a/UIInfoSuite2/UIElements/ExperienceBar.cs
+++ b/UIInfoSuite2/UIElements/ExperienceBar.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Enums;
@@ -18,6 +18,7 @@ public partial class ExperienceBar
 #region Properties
   private readonly PerScreen<Item> _previousItem = new();
   private readonly PerScreen<int[]> _currentExperience = new(() => new int[5]);
+  private readonly PerScreen<int> _currentMasteryXP = new(() => 0);
   private readonly PerScreen<int[]> _currentLevelExtenderExperience = new(() => new int[5]);
   private readonly PerScreen<int> _currentSkillLevel = new(() => 0);
   private readonly PerScreen<int> _experienceRequiredToLevel = new(() => -1);
@@ -261,7 +262,12 @@ public partial class ExperienceBar
       _currentExperience.Value[i] = Game1.player.experiencePoints[i];
     }
 
-    if (_levelExtenderApi != null)
+    if (Game1.player.Level >= 25)
+    {
+      _currentMasteryXP.Value = (int)Game1.stats.Get("MasteryExp");
+    }
+
+      if (_levelExtenderApi != null)
     {
       for (var i = 0; i < _currentLevelExtenderExperience.Value.Length; ++i)
       {
@@ -323,7 +329,7 @@ public partial class ExperienceBar
 
     if (displayExperience)
     {
-      if (ExperienceGainTextEnabled && _experienceRequiredToLevel.Value > 0)
+      if (ExperienceGainTextEnabled && _experienceRequiredToLevel.Value > 0 && Game1.player.Level < 25)
       {
         int currentExperienceToUse = Game1.player.experiencePoints[currentLevelIndex];
         int previousExperienceToUse = _currentExperience.Value[currentLevelIndex];
@@ -341,6 +347,14 @@ public partial class ExperienceBar
             new DisplayedExperienceValue(experienceGain, Game1.player.getLocalPosition(Game1.viewport))
           );
         }
+      }
+      else if(Game1.player.Level >= 25 && ((int)Game1.stats.Get("MasteryExp") < 100000))
+      {
+          int newMasteryXP = (int)Game1.stats.Get("MasteryExp") - _currentMasteryXP.Value;
+          _currentMasteryXP.Value = (int)Game1.stats.Get("MasteryExp");
+          _displayedExperienceValues.Value.Add(
+            new DisplayedExperienceValue(newMasteryXP, Game1.player.getLocalPosition(Game1.viewport))
+          );
       }
 
       _currentExperience.Value[currentLevelIndex] = Game1.player.experiencePoints[currentLevelIndex];

--- a/UIInfoSuite2/UIElements/ExperienceElements/DisplayedExperienceBar.cs
+++ b/UIInfoSuite2/UIElements/ExperienceElements/DisplayedExperienceBar.cs
@@ -82,8 +82,18 @@ public class DisplayedExperienceBar
         0.85f
       );
 
+      String levelNumber = "";
+      if (Game1.player.Level < 25)
+      {
+        levelNumber = currentLevel.ToString();
+      }
+      else
+      {
+        levelNumber = MasteryTrackerMenu.getCurrentMasteryLevel().ToString();
+      }
+
       Game1.drawWithBorder(
-        currentLevel.ToString(),
+        levelNumber,
         Color.Black * 0.6f,
         Color.Black,
         new Vector2(leftSide + 33, Game1.graphics.GraphicsDevice.Viewport.TitleSafeArea.Bottom - 70)


### PR DESCRIPTION
I had found this issue/feature request (I came here looking to make the same request): https://github.com/Annosz/UIInfoSuite2/issues/479

and decided to try and implement it myself. This bit of code should get the XP text over the player's head functioning past level 25 (which is apparently what the game code considers max overall level before mastery). It also implements the other portion of the feature request about the graph showing progress on the current mastery Level.

There are 3 things I wanted to note that are still "TODO" items:
1) I tried making the color of the bar match the color that was used on the mastery progress bar in the main UI but i can't seem to get the color right no matter what I do.  It seems to be over-saturating anything I put in.
2) UI Info suite seems to have some way of accessing the game's icons through a rect based system (I assume tied to a sprite sheet).  I don't know where this sheet is or what the coordinates would be for a "star" icon, so i used the luck icon for now since that was already implemented and is currently unused.
3) Due to the amount of EXP needed for mastery levels, it overflows the bar quite easily.  I tried bumping up the "MaxBarWidth" value in DisplayedExperienceBar.cs but it didn't seem to affect anything.  I have noticed it overflowing during normal gameplay before, so i'm not sure if this is a dealbreaker for this pull request or not.

Let me know if you have any tips on handling any of these 3 items and I can make updates and a new pull if you'd like.