### PR TITLE
Added watered status onto UI when crop is hovered

### DIFF
--- a/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
+++ b/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
@@ -432,6 +432,10 @@ internal class ShowCropAndBarrelTime : IDisposable
         string cropName = DropsHelper.GetCropHarvestName(crop);
         string daysLeftStr = daysLeft <= 0 ? I18n.ReadyToHarvest() : $"{daysLeft} {I18n.Days()}";
         entries.Add($"{cropName}: {daysLeftStr}");
+
+        string waterStatus = hoeDirt.state.Value == 1 ? I18n.Watered() : I18n.NotWatered();
+        entries.Add(waterStatus);
+
         if (!string.IsNullOrEmpty(fertilizerStr))
         {
           fertilizerStr = $"({I18n.With()} {fertilizerStr})";

--- a/UIInfoSuite2/i18n/default.json
+++ b/UIInfoSuite2/i18n/default.json
@@ -18,6 +18,8 @@
   "ReadyToHarvest": "Ready to harvest!",
   "With": "with",
   "Fertilized": "fertilized",
+  "Watered": "Watered",
+  "NotWatered": "Not Watered",
   "DoesNotProduceThisSeason": "Does not produce this season",
   //Tree
   "Stump": "stump",


### PR DESCRIPTION
Added localization entries to indicate watering status to `default.json` and used the `CropRender` function to add the watering status of a crop using `hoeDirt.state.value == 1`. Works well in actual gameplay on all farmland and garden pots.

![watered](https://github.com/Annosz/UIInfoSuite2/assets/60415221/ba09c531-22d2-45ff-b74f-9d62f129f090)
![notwatered](https://github.com/Annosz/UIInfoSuite2/assets/60415221/2bb8895d-fe4e-4f72-a4cf-119e88097b31)
