### PR TITLE
Fix multiplayer map (LocationOfTownfolk)

### DIFF
--- a/UIInfoSuite2/Infrastructure/ModConstants.cs
+++ b/UIInfoSuite2/Infrastructure/ModConstants.cs
@@ -1,0 +1,15 @@
+namespace UIInfoSuite2.Infrastructure;
+
+/// <summary>The constant values used by the mod.</summary>
+public static class ModConstants
+{
+  /*********
+  ** Accessors
+  *********/
+  /// <summary>The network message IDs used by the mod.</summary>
+  public static class MessageIds
+  {
+    /// <summary>A message from the host containing NPC location data.</summary>
+    public const string TownFolksMultiplayerSync = "TownFolksMultiplayerSync";
+  }
+}

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -22,16 +23,20 @@ internal class LocationOfTownsfolk : IDisposable
 #region Internal record
 
   // Inspired by Bouhm "NPCMapLocations"
-  public record MultiPlayerSyncData(int X, int Y)
+  public record MultiPlayerSyncData(int X, int Y, int Tx, int Ty, string MapPath, string Value)
   {
     // GameLocation data
     public static MultiPlayerSyncData Create(Point tile, GameLocation gameLocation)
     {
+      string Value = gameLocation.Name;
+      string MapPath = gameLocation.mapPath.Value;
+      int Tx = tile.X;
+      int Ty = tile.Y;
       var aux = WorldMapManager.GetPositionData(gameLocation, tile);
       int X = (int)aux.GetMapPixelPosition(gameLocation, tile).X;
       int Y = (int)aux.GetMapPixelPosition(gameLocation, tile).Y;
 
-      return new MultiPlayerSyncData(X, Y);
+      return new MultiPlayerSyncData(X, Y, Tx, Ty, MapPath, Value);
     }
   }
 #endregion
@@ -449,10 +454,24 @@ internal class LocationOfTownsfolk : IDisposable
         return characterMapAreaPosition.GetMapPixelPosition(character.currentLocation, characterNormalizedTile);
       }
     }
+    
     // Multiplayer Sync
-    else
+    else if (_multiPlayerSyncData.ContainsKey(character.Name))
     {
-      return new Vector2(_multiPlayerSyncData[character.Name].X, _multiPlayerSyncData[character.Name].Y);
+      characterMapAreaPosition = WorldMapManager.GetPositionData(
+        new GameLocation(
+          _multiPlayerSyncData[character.Name].MapPath,
+          _multiPlayerSyncData[character.Name].Value), 
+        new Point(
+          _multiPlayerSyncData[character.Name].Tx, 
+          _multiPlayerSyncData[character.Name].Ty));
+
+      if (playerMapAreaPosition != null &&
+          characterMapAreaPosition != null &&
+          !(characterMapAreaPosition.Region.Id != playerMapAreaPosition.Region.Id))
+      {
+        return new Vector2(_multiPlayerSyncData[character.Name].X, _multiPlayerSyncData[character.Name].Y);
+      }
     }
 
     return null;

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -40,7 +40,7 @@ internal class LocationOfTownsfolk : IDisposable
   private SocialPage _socialPage = null!;
   private string[] _friendNames = null!;
   private readonly List<NPC> _townsfolk = new();
-  private Dictionary<string, MultiPlayerSyncData> _multiPlayerSyncData = new();
+  private static Dictionary<string, MultiPlayerSyncData> _multiPlayerSyncData = new();
   private readonly List<OptionsCheckbox> _checkboxes = new();
 
   private readonly ModOptions _options;
@@ -344,7 +344,7 @@ internal class LocationOfTownsfolk : IDisposable
                                    character.id != -1;
         if (shouldDrawCharacter)
         {
-          DrawNPC(character, namesToShow, _multiPlayerSyncData);
+          DrawNPC(character, namesToShow);
         }
       }
       catch (Exception ex)
@@ -362,14 +362,13 @@ internal class LocationOfTownsfolk : IDisposable
     IClickableMenu.drawHoverText(Game1.spriteBatch, hoverText, Game1.smallFont);
   }
 
-  private static void DrawNPC(NPC character, List<string> namesToShow, Dictionary<string, MultiPlayerSyncData> multiPlayerSyncData)
+  private static void DrawNPC(NPC character, List<string> namesToShow)
   {
     // Compare with the game code - MapPage.drawMiniPortraits
 
     Vector2?
       location = GetMapCoordinatesForNPC(
-        character,
-        multiPlayerSyncData
+        character
       ); // location is the absolute position or null if the npc is not on the map
     if (location is null)
     {
@@ -419,7 +418,7 @@ internal class LocationOfTownsfolk : IDisposable
     DrawQuestsForNPC(character, (int)offsetLocation.X, (int)offsetLocation.Y);
   }
 
-  private static Vector2? GetMapCoordinatesForNPC(NPC character, Dictionary<string, MultiPlayerSyncData> multiPlayerSyncData)
+  private static Vector2? GetMapCoordinatesForNPC(NPC character)
   {
     var playerNormalizedTile = new Point(Math.Max(0, Game1.player.TilePoint.X), Math.Max(0, Game1.player.TilePoint.Y));
     MapAreaPosition playerMapAreaPosition =
@@ -435,9 +434,9 @@ internal class LocationOfTownsfolk : IDisposable
 
     // Checking if the player is the main player.
     // If it is, do as we normally do.
-    // The second check is to prevent spam on the other players side if the mod is not updated
-    // on the MainPlayer side.
-    if (Context.IsMainPlayer || multiPlayerSyncData.Keys.Count == 0)
+    // The second check is a "fallback" to prevent errors if the MainPlayer doesn't have the
+    // mod on the last version.
+    if (Context.IsMainPlayer || _multiPlayerSyncData.Keys.Count == 0)
     {
       characterNormalizedTile = new Point(Math.Max(0, character.TilePoint.X), Math.Max(0, character.TilePoint.Y));
       characterMapAreaPosition =
@@ -453,7 +452,7 @@ internal class LocationOfTownsfolk : IDisposable
     // Multiplayer Sync
     else
     {
-      return new Vector2(multiPlayerSyncData[character.Name].X, multiPlayerSyncData[character.Name].Y);
+      return new Vector2(_multiPlayerSyncData[character.Name].X, _multiPlayerSyncData[character.Name].Y);
     }
 
     return null;

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -435,7 +435,9 @@ internal class LocationOfTownsfolk : IDisposable
 
     // Checking if the player is the main player.
     // If it is, do as we normally do.
-    if (Context.IsMainPlayer)
+    // The second check is to prevent spam on the other players side if the mod is not updated
+    // on the MainPlayer side.
+    if (Context.IsMainPlayer || multiPlayerSyncData.Keys.Count == 0)
     {
       characterNormalizedTile = new Point(Math.Max(0, character.TilePoint.X), Math.Max(0, character.TilePoint.Y));
       characterMapAreaPosition =

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -33,10 +33,6 @@ internal class LocationOfTownsfolk : IDisposable
       string Name = gameLocation.Name;
       int Tx = tile.X;
       int Ty = tile.Y;
-      /*
-      var aux = WorldMapManager.GetPositionData(gameLocation, tile);
-      int X = (int)aux.GetMapPixelPosition(gameLocation, tile).X;
-      int Y = (int)aux.GetMapPixelPosition(gameLocation, tile).Y;*/
 
       return new MultiPlayerSyncData(MapPath, Name, Tx, Ty);
     }

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;

--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -26,7 +24,7 @@ internal class LocationOfTownsfolk : IDisposable
   // Inspired by Bouhm "NPCMapLocations"
   public record MultiPlayerSyncData(string MapPath, string Name, int Tx, int Ty)
   {
-    // GameLocation data
+    // Sync data record
     public static MultiPlayerSyncData Create(Point tile, GameLocation gameLocation)
     {
       string MapPath = gameLocation.mapPath.Value;
@@ -535,6 +533,7 @@ internal class LocationOfTownsfolk : IDisposable
     );
   }
 
+  // This method is used to create "unique keys" for each entry in the MP Sync data.
   private static string GetMpSyncKey(Character character)
   {
     return $"{character.Name}@{character.currentLocation.GetLocationContextId()}";


### PR DESCRIPTION
This patch was greatly inspired by [Bouhm NPCMapLocations mod](https://github.com/Bouhm/stardew-valley-mods/tree/main/NPCMapLocations).

By using the `_helper.Multiplayer.SendMessage`, we can make the _MainPlayer_ send the up-to-date location from all NPCs in the map. The approached used all the previously implemented API's without modifications to the function calls.

Furthermore, from now on, we are going to check the NPCs locations every 5 ticks to avoid message spam and unnecessary NPC location updates.