### PR TITLE
Add NPC IsInvisible check to LocationOfTownsfolk

### DIFF
--- a/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
+++ b/UIInfoSuite2/UIElements/LocationOfTownsfolk.cs
@@ -280,7 +280,7 @@ internal class LocationOfTownsfolk : IDisposable
       {
         bool shouldDrawCharacter = Game1.player.friendshipData.ContainsKey(character.Name) &&
                                    _options.ShowLocationOfFriends.GetOrDefault(character.Name, true) &&
-                                   character.id != -1;
+                                   character.id != -1 && character.IsInvisible != true;
         if (shouldDrawCharacter)
         {
           DrawNPC(character, namesToShow);


### PR DESCRIPTION
NOTE: If I understand correctly, you're currently in the process of rewriting UI Info Suite and therefore may not be interested in PRs that change the current implementation of it. I wanted to make this PR anyway so that I flagged the issue of NPC invisibility for you in case you wanted to adjust the new implementation to deal with it :)

**Issue**
Currently NPCs who are set as invisible (like Elliott on his 14-heart event or other NPCs via the trigger action implemented in 1.6) will still be visible on the world map despite not being visible or able to be interacted with in game.

**Change**
Added `&& character.IsInvisible != true` inside code that determines whether a character should be eligible to be drawn on the map.

**Purpose**
If an NPC is invisible, this change will prevent them from being eligible for being on the list of villagers to display on the world map. Once they are visible, they will be added to the list and can be displayed on the world map.

**Testing**
Has been tested and confirmed to work in single player and multiplayer. Works with vanilla and custom NPCs. Changes to NPC visibility on the map don't happen until next day if NPC is made invisible/visible partway through a day.