### PR TITLE
fix: custom bush name from Tokenizable_strings if possible

### DIFF
--- a/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
+++ b/UIInfoSuite2/UIElements/ShowCropAndBarrelTime.cs
@@ -12,6 +12,7 @@ using StardewValley.ItemTypeDefinitions;
 using StardewValley.Menus;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
+using StardewValley.TokenizableStrings;
 using UIInfoSuite2.Compatibility;
 using UIInfoSuite2.Compatibility.CustomBush;
 using UIInfoSuite2.Infrastructure.Extensions;
@@ -539,7 +540,9 @@ internal class ShowCropAndBarrelTime : IDisposable
         {
           droppedItems.Clear();
           willProduceThisSeason = customBushData.Seasons.Contains(Game1.season);
-          bushName = $"{customBushData.DisplayName} Bush";
+          string displayName = customBushData.DisplayName;
+          if(displayName.Contains("LocalizedText")) displayName = TokenParser.ParseText(displayName);
+          bushName = $"{displayName} Bush";
           ageToMature = customBushData.AgeToProduce;
           inProductionPeriod = Game1.dayOfMonth >= customBushData.DayToBeginProducing;
           daysUntilProductionPeriod = inProductionPeriod ? 0 : 22 - Game1.dayOfMonth;


### PR DESCRIPTION
Fix custom bush name from Tokenizable_strings if possible
![20241027102554_1](https://github.com/user-attachments/assets/10b12c8d-4d5f-476e-83d8-347fda67b2ce)
![20241027102546_1](https://github.com/user-attachments/assets/16789619-38b8-4598-ba08-07c1688a64ec)
