### PR TITLE
Add new feature of ShowItemEffectRanges.

### DIFF
--- a/UIInfoSuite2/ModEntry.cs
+++ b/UIInfoSuite2/ModEntry.cs
@@ -14,7 +14,7 @@ namespace UIInfoSuite2;
 public class ModEntry : Mod
 {
   private static SkipIntro _skipIntro; // Needed so GC won't throw away object with subscriptions
-  private static ModConfig _modConfig;
+  public static ModConfig _modConfig;
 
   private static EventHandler<ButtonsChangedEventArgs> _calendarAndQuestKeyBindingsHandler;
 
@@ -91,6 +91,26 @@ public class ModEntry : Mod
       getValue: () => _modConfig.OpenQuestBoardKeybind,
       setValue: value => _modConfig.OpenQuestBoardKeybind = value
     );
+    // Show item effect ranges
+    configMenu.AddSectionTitle(
+      ModManifest,
+      text: () => I18n.Keybinds_Subtitle_ShowRange_DisplayedName(),
+      tooltip: () => I18n.Keybinds_Subtitle_ShowRange_Tooltip()
+      );
+    configMenu.AddKeybindList(
+      ModManifest,
+      name: () => I18n.Keybinds_ShowOneRange_DisplayedName(),
+      tooltip: () => I18n.Keybinds_ShowOneRange_Tooltip(),
+      getValue: () => _modConfig.ShowOneRange,
+      setValue: value => _modConfig.ShowOneRange = value
+    );
+    configMenu.AddKeybindList(
+      ModManifest,
+      name: () => I18n.Keybinds_ShowAllRange_DisplayedName(),
+      tooltip: () => I18n.Keybinds_ShowAllRange_Tooltip(),
+      getValue: () => _modConfig.ShowAllRange,
+      setValue: value => _modConfig.ShowAllRange = value
+      );
   }
 #endregion
 

--- a/UIInfoSuite2/Options/ModConfig.cs
+++ b/UIInfoSuite2/Options/ModConfig.cs
@@ -3,10 +3,12 @@ using StardewModdingAPI.Utilities;
 
 namespace UIInfoSuite2.Options;
 
-internal class ModConfig
+public class ModConfig
 {
   public bool ShowOptionsTabInMenu { get; set; } = true;
   public string ApplyDefaultSettingsFromThisSave { get; set; } = "JohnDoe_123456789";
   public KeybindList OpenCalendarKeybind { get; set; } = KeybindList.ForSingle(SButton.B);
   public KeybindList OpenQuestBoardKeybind { get; set; } = KeybindList.ForSingle(SButton.H);
+  public KeybindList ShowOneRange { get; set; } = KeybindList.ForSingle(SButton.LeftControl);
+  public KeybindList ShowAllRange { get; set; } = KeybindList.Parse("LeftControl + LeftAlt");
 }

--- a/UIInfoSuite2/Options/ModOptions.cs
+++ b/UIInfoSuite2/Options/ModOptions.cs
@@ -19,6 +19,8 @@ internal record ModOptions
   public bool ShowAnimalsNeedPets { get; set; } = true;
   public bool HideAnimalPetOnMaxFriendship { get; set; } = true;
   public bool ShowItemEffectRanges { get; set; } = true;
+  public bool ButtonControlShow { get; set; } = false;
+  public bool ShowBombRange { get; set; } = false;
   public bool ShowItemsRequiredForBundles { get; set; } = true;
   public bool ShowHarvestPricesInShop { get; set; } = true;
   public bool DisplayCalendarAndBillboard { get; set; } = true;

--- a/UIInfoSuite2/Options/ModOptionsPageHandler.cs
+++ b/UIInfoSuite2/Options/ModOptionsPageHandler.cs
@@ -242,13 +242,32 @@ internal class ModOptionsPageHandler : IDisposable
         v => options.ShowCropAndBarrelTooltip = v
       )
     );
-    _optionsElements.Add(
-      new ModOptionsCheckbox(
-        _helper.SafeGetString(nameof(options.ShowItemEffectRanges)),
+    var ScarecrowAndSprinklerRangeIcon = new ModOptionsCheckbox(
+        I18n.ShowItemEffectRanges(),
         whichOption++,
         showScarecrowAndSprinklerRange.ToggleOption,
         () => options.ShowItemEffectRanges,
         v => options.ShowItemEffectRanges = v
+      );
+    _optionsElements.Add(ScarecrowAndSprinklerRangeIcon);
+    _optionsElements.Add(
+      new ModOptionsCheckbox(
+        I18n.ButtonControlShow(),
+        whichOption++,
+        showScarecrowAndSprinklerRange.ToggleButtonControlShowOption,
+        () => options.ButtonControlShow,
+        v => options.ButtonControlShow = v,
+        ScarecrowAndSprinklerRangeIcon
+      )
+    );
+    _optionsElements.Add(
+      new ModOptionsCheckbox(
+        I18n.ShowBombRange(),
+        whichOption++,
+        showScarecrowAndSprinklerRange.ToggleShowBombRangeOption,
+        () => options.ShowBombRange,
+        v => options.ShowBombRange = v,
+        ScarecrowAndSprinklerRangeIcon
       )
     );
     _optionsElements.Add(

--- a/UIInfoSuite2/UIElements/ShowItemEffectRanges.cs
+++ b/UIInfoSuite2/UIElements/ShowItemEffectRanges.cs
@@ -16,16 +16,25 @@ namespace UIInfoSuite2.UIElements;
 
 internal class ShowItemEffectRanges : IDisposable
 {
-#region Properties
-  private readonly PerScreen<HashSet<Point>> _effectiveArea = new(() => new HashSet<Point>());
+  #region Properties
+  private readonly PerScreen<List<Point>> _effectiveAreaCurrent = new(() => new List<Point>());
+  private readonly PerScreen<HashSet<Point>> _effectiveAreaOther = new(() => new HashSet<Point>());
+  private readonly PerScreen<HashSet<Point>> _effectiveAreaIntersection = new(() => new HashSet<Point>());
 
   private readonly Mutex _mutex = new();
 
   private readonly IModHelper _helper;
-#endregion
+
+  private bool ButtonControlShow { get; set; }
+  private bool ShowBombRange { get; set; }
+
+  private bool ButtonShowOneRange { get; set; }
+  private bool ButtonShowAllRanges { get; set; }
+
+  #endregion
 
 
-#region Lifecycle
+  #region Lifecycle
   public ShowItemEffectRanges(IModHelper helper)
   {
     _helper = helper;
@@ -38,6 +47,8 @@ internal class ShowItemEffectRanges : IDisposable
 
   public void ToggleOption(bool showItemEffectRanges)
   {
+    ToggleButtonControlShowOption(showItemEffectRanges);
+
     _helper.Events.Display.RenderingHud -= OnRenderingHud;
     _helper.Events.GameLoop.UpdateTicked -= OnUpdateTicked;
 
@@ -47,10 +58,25 @@ internal class ShowItemEffectRanges : IDisposable
       _helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
     }
   }
-#endregion
+
+  public void ToggleButtonControlShowOption(bool buttonControlShow)
+  {
+    ButtonControlShow = buttonControlShow;
+
+    _helper.Events.Input.ButtonsChanged -= OnButtonChanged;
+    if (buttonControlShow)
+    {
+      _helper.Events.Input.ButtonsChanged += OnButtonChanged;
+    }
+  }
+  public void ToggleShowBombRangeOption(bool showBombRange)
+  {
+    ShowBombRange = showBombRange;
+  }
+  #endregion
 
 
-#region Event subscriptions
+  #region Event subscriptions
   private void OnUpdateTicked(object? sender, UpdateTickedEventArgs e)
   {
     if (!e.IsMultipleOf(4))
@@ -68,7 +94,9 @@ internal class ShowItemEffectRanges : IDisposable
     {
       try
       {
-        _effectiveArea.Value.Clear();
+        _effectiveAreaCurrent.Value.Clear();
+        _effectiveAreaOther.Value.Clear();
+        _effectiveAreaIntersection.Value.Clear();
       }
       finally
       {
@@ -79,9 +107,11 @@ internal class ShowItemEffectRanges : IDisposable
     if (Game1.activeClickableMenu == null && UIElementUtils.IsRenderingNormally())
     {
       UpdateEffectiveArea();
+      GetOverlapValue();
+      if (ButtonShowOneRange) ButtonShowOneRange = false;
+      if (ButtonShowAllRanges) ButtonShowAllRanges = false;
     }
   }
-
 
   private void OnRenderingHud(object? sender, RenderingHudEventArgs e)
   {
@@ -89,7 +119,7 @@ internal class ShowItemEffectRanges : IDisposable
     {
       try
       {
-        foreach (Point point in _effectiveArea.Value)
+        foreach (Point point in _effectiveAreaOther.Value)
         {
           var position = new Vector2(
             point.X * Utility.ModifyCoordinateFromUIScale(Game1.tileSize),
@@ -107,6 +137,24 @@ internal class ShowItemEffectRanges : IDisposable
             0.01f
           );
         }
+        foreach (Point point in _effectiveAreaIntersection.Value)
+        {
+          var position = new Vector2(
+            point.X * Utility.ModifyCoordinateFromUIScale(Game1.tileSize),
+            point.Y * Utility.ModifyCoordinateFromUIScale(Game1.tileSize)
+          );
+          e.SpriteBatch.Draw(
+            Game1.mouseCursors,
+            Utility.ModifyCoordinatesForUIScale(Game1.GlobalToLocal(Utility.ModifyCoordinatesForUIScale(position))),
+            new Rectangle(194, 388, 16, 16),
+            Color.Red * 0.7f,
+            0.0f,
+            Vector2.Zero,
+            Utility.ModifyCoordinateForUIScale(Game1.pixelZoom),
+            SpriteEffects.None,
+            0.01f
+          );
+        }
       }
       finally
       {
@@ -114,10 +162,28 @@ internal class ShowItemEffectRanges : IDisposable
       }
     }
   }
-#endregion
+
+  private void OnButtonChanged(object? sender, ButtonsChangedEventArgs e)
+  {
+    if (ModEntry._modConfig != null)
+    {
+      if (Context.IsPlayerFree)
+      {
+        if (ModEntry._modConfig.ShowOneRange.IsDown())
+        {
+          ButtonShowOneRange = true;
+        }
+        if (ModEntry._modConfig.ShowAllRange.IsDown())
+        {
+          ButtonShowAllRanges = true;
+        }
+      }
+    }
+  }
+  #endregion
 
 
-#region Logic
+  #region Logic
   private void UpdateEffectiveArea()
   {
     int[][] arrayToUse;
@@ -133,13 +199,103 @@ internal class ShowItemEffectRanges : IDisposable
       {
         if (nextBuilding is JunimoHut nextHut)
         {
-          AddTilesToHighlightedArea(arrayToUse, nextHut.tileX.Value + 1, nextHut.tileY.Value + 1);
+          AddTilesToHighlightedArea(arrayToUse, false, nextHut.tileX.Value + 1, nextHut.tileY.Value + 1);
         }
       }
     }
 
     // Every other item is here
-    if (Game1.player.CurrentItem is Object currentItem && currentItem.isPlaceable())
+    if (ButtonControlShow && (ButtonShowOneRange || ButtonShowAllRanges))
+    {
+      Vector2 gamepadTile = Game1.player.CurrentTool != null
+              ? Utility.snapToInt(Game1.player.GetToolLocation() / Game1.tileSize)
+              : Utility.snapToInt(Game1.player.GetGrabTile());
+      Vector2 mouseTile = Game1.currentCursorTile;
+      Vector2 tile = Game1.options.gamepadControls && Game1.timerUntilMouseFade <= 0 ? gamepadTile : mouseTile;
+      if (Game1.currentLocation.Objects?.TryGetValue(tile, out StardewValley.Object? currentObject) ?? false)
+      {
+        if (currentObject != null)
+        {
+          Vector2 currentTile = Game1.GetPlacementGrabTile();
+          Game1.isCheckingNonMousePlacement = !Game1.IsPerformingMousePlacement();
+          Vector2 validTile = Utility.snapToInt(
+                                  Utility.GetNearbyValidPlacementPosition(
+                                  Game1.player,
+                                  Game1.currentLocation,
+                                  currentObject,
+                                  (int)currentTile.X * Game1.tileSize,
+                                  (int)currentTile.Y * Game1.tileSize
+                                  )
+                              ) /
+                              Game1.tileSize;
+          Game1.isCheckingNonMousePlacement = false;
+
+          if (currentObject.Name.IndexOf("arecrow", StringComparison.OrdinalIgnoreCase) >= 0)
+          {
+            string itemName = currentObject.Name;
+            arrayToUse = itemName.Contains("eluxe")
+                ? GetDistanceArray(ObjectsWithDistance.DeluxeScarecrow, false, currentObject)
+                : GetDistanceArray(ObjectsWithDistance.Scarecrow, false, currentObject);
+            AddTilesToHighlightedArea(arrayToUse, true, (int)validTile.X, (int)validTile.Y);
+
+            if (ButtonShowAllRanges)
+            {
+              similarObjects = GetSimilarObjectsInLocation("arecrow");
+              foreach (Object next in similarObjects)
+              {
+                if (!next.Equals(currentObject))
+                {
+                  var arrayToUse_ = next.Name.IndexOf("eluxe", StringComparison.OrdinalIgnoreCase) >= 0
+                    ? GetDistanceArray(ObjectsWithDistance.DeluxeScarecrow, false, next)
+                    : GetDistanceArray(ObjectsWithDistance.Scarecrow, false, next);
+                  if (!arrayToUse_.SequenceEqual(arrayToUse))
+                  {
+                    AddTilesToHighlightedArea(arrayToUse, false, (int)next.TileLocation.X, (int)next.TileLocation.Y);
+                  }
+                }
+              }
+            }
+          }
+          else if (currentObject.Name.IndexOf("sprinkler", StringComparison.OrdinalIgnoreCase) >= 0)
+          {
+            IEnumerable<Vector2> unplacedSprinklerTiles = currentObject.GetSprinklerTiles();
+            if (currentObject.TileLocation != validTile)
+            {
+              unplacedSprinklerTiles = unplacedSprinklerTiles.Select(tile => tile - currentObject.TileLocation + validTile);
+            }
+            AddTilesToHighlightedArea(unplacedSprinklerTiles, true);
+
+            if (ButtonShowAllRanges)
+            {
+              similarObjects = GetSimilarObjectsInLocation("sprinkler");
+              foreach (Object next in similarObjects)
+              {
+                if (!next.Equals(currentObject))
+                {
+                  AddTilesToHighlightedArea(next.GetSprinklerTiles(), false);
+                }
+              }
+            }
+          }
+          else if (currentObject.Name.IndexOf("bee house", StringComparison.OrdinalIgnoreCase) >= 0)
+          {
+            arrayToUse = GetDistanceArray(ObjectsWithDistance.Beehouse);
+            AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
+          }
+          else if (currentObject.Name.IndexOf("mushroom log", StringComparison.OrdinalIgnoreCase) >= 0)
+          {
+            arrayToUse = GetDistanceArray(ObjectsWithDistance.MushroomLog);
+            AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
+          }
+          else if (currentObject.Name.IndexOf("mossy seed", StringComparison.OrdinalIgnoreCase) >= 0)
+          {
+            arrayToUse = GetDistanceArray(ObjectsWithDistance.MossySeed);
+            AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
+          }
+        }
+      }
+    }
+    else if (Game1.player.CurrentItem is Object currentItem && currentItem.isPlaceable())
     {
       string itemName = currentItem.Name;
 
@@ -162,7 +318,7 @@ internal class ShowItemEffectRanges : IDisposable
         arrayToUse = itemName.Contains("eluxe")
           ? GetDistanceArray(ObjectsWithDistance.DeluxeScarecrow, false, currentItem)
           : GetDistanceArray(ObjectsWithDistance.Scarecrow, false, currentItem);
-        AddTilesToHighlightedArea(arrayToUse, (int)validTile.X, (int)validTile.Y);
+        AddTilesToHighlightedArea(arrayToUse, true, (int)validTile.X, (int)validTile.Y);
 
         similarObjects = GetSimilarObjectsInLocation("arecrow");
         foreach (Object next in similarObjects)
@@ -170,7 +326,7 @@ internal class ShowItemEffectRanges : IDisposable
           arrayToUse = next.Name.IndexOf("eluxe", StringComparison.OrdinalIgnoreCase) >= 0
             ? GetDistanceArray(ObjectsWithDistance.DeluxeScarecrow, false, next)
             : GetDistanceArray(ObjectsWithDistance.Scarecrow, false, next);
-          AddTilesToHighlightedArea(arrayToUse, (int)next.TileLocation.X, (int)next.TileLocation.Y);
+          AddTilesToHighlightedArea(arrayToUse, false, (int)next.TileLocation.X, (int)next.TileLocation.Y);
         }
       }
       else if (itemName.IndexOf("sprinkler", StringComparison.OrdinalIgnoreCase) >= 0)
@@ -194,34 +350,51 @@ internal class ShowItemEffectRanges : IDisposable
           unplacedSprinklerTiles = unplacedSprinklerTiles.Select(tile => tile - currentItem.TileLocation + validTile);
         }
 
-        AddTilesToHighlightedArea(unplacedSprinklerTiles);
+        AddTilesToHighlightedArea(unplacedSprinklerTiles, true);
 
         similarObjects = GetSimilarObjectsInLocation("sprinkler");
         foreach (Object next in similarObjects)
         {
           // Absolute tile positions
-          AddTilesToHighlightedArea(next.GetSprinklerTiles());
+          AddTilesToHighlightedArea(next.GetSprinklerTiles(), false);
         }
       }
       else if (itemName.IndexOf("bee house", StringComparison.OrdinalIgnoreCase) >= 0)
       {
         arrayToUse = GetDistanceArray(ObjectsWithDistance.Beehouse);
-        AddTilesToHighlightedArea(arrayToUse, (int)validTile.X, (int)validTile.Y);
+        AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
       }
       else if (itemName.IndexOf("mushroom log", StringComparison.OrdinalIgnoreCase) >= 0)
       {
         arrayToUse = GetDistanceArray(ObjectsWithDistance.MushroomLog);
-        AddTilesToHighlightedArea(arrayToUse, (int)validTile.X, (int)validTile.Y);
+        AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
       }
       else if (itemName.IndexOf("mossy seed", StringComparison.OrdinalIgnoreCase) >= 0)
       {
         arrayToUse = GetDistanceArray(ObjectsWithDistance.MossySeed);
-        AddTilesToHighlightedArea(arrayToUse, (int)validTile.X, (int)validTile.Y);
+        AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
+      }
+      else if (ShowBombRange && itemName.IndexOf("Bomb", StringComparison.OrdinalIgnoreCase) >= 0)
+      {
+        if (itemName.Contains("ega"))
+        {
+          arrayToUse = GetDistanceArray(ObjectsWithDistance.MegaBomb);
+        }
+        else if (itemName.Contains("herry"))
+        {
+          arrayToUse = GetDistanceArray(ObjectsWithDistance.CherryBomb);
+        }
+        else
+        {
+          arrayToUse = GetDistanceArray(ObjectsWithDistance.Bomb);
+        }
+
+        AddTilesToHighlightedArea(arrayToUse, false, (int)validTile.X, (int)validTile.Y);
       }
     }
   }
 
-  private void AddTilesToHighlightedArea(IEnumerable<Vector2> tiles, int xPos = 0, int yPos = 0)
+  private void AddTilesToHighlightedArea(IEnumerable<Vector2> tiles, bool overlap, int xPos = 0, int yPos = 0)
   {
     if (_mutex.WaitOne())
     {
@@ -232,7 +405,14 @@ internal class ShowItemEffectRanges : IDisposable
           var point = tile.ToPoint();
           point.X += xPos;
           point.Y += yPos;
-          _effectiveArea.Value.Add(point);
+          if (overlap)
+          {
+            _effectiveAreaCurrent.Value.Add(point);
+          }
+          else
+          {
+            _effectiveAreaOther.Value.Add(point);
+          }
         }
       }
       finally
@@ -242,7 +422,7 @@ internal class ShowItemEffectRanges : IDisposable
     }
   }
 
-  private void AddTilesToHighlightedArea(int[][] tileMap, int xPos = 0, int yPos = 0)
+  private void AddTilesToHighlightedArea(int[][] tileMap, bool overlap, int xPos = 0, int yPos = 0)
   {
     int xOffset = tileMap.Length / 2;
 
@@ -257,7 +437,14 @@ internal class ShowItemEffectRanges : IDisposable
           {
             if (tileMap[i][j] == 1)
             {
-              _effectiveArea.Value.Add(new Point(xPos + i - xOffset, yPos + j - yOffset));
+              if (overlap)
+              {
+                _effectiveAreaCurrent.Value.Add(new Point(xPos + i - xOffset, yPos + j - yOffset));
+              }
+              else
+              {
+                _effectiveAreaOther.Value.Add(new Point(xPos + i - xOffset, yPos + j - yOffset));
+              }
             }
           }
         }
@@ -290,7 +477,18 @@ internal class ShowItemEffectRanges : IDisposable
     return result;
   }
 
-#region Distance map
+  /// <summary>
+  /// Extract the overlapping area.
+  /// </summary>
+  private void GetOverlapValue()
+  {
+    PerScreen<HashSet<Point>> temp = new PerScreen<HashSet<Point>>();
+    _effectiveAreaIntersection.Value = _effectiveAreaOther.Value.Intersect(_effectiveAreaCurrent.Value).ToHashSet();
+    temp.Value = _effectiveAreaCurrent.Value.Except(_effectiveAreaOther.Value).ToHashSet();
+    _effectiveAreaOther.Value = _effectiveAreaOther.Value.Except(_effectiveAreaCurrent.Value).ToHashSet();
+    _effectiveAreaOther.Value = _effectiveAreaOther.Value.Union(temp.Value).ToHashSet();
+  }
+  #region Distance map
   private enum ObjectsWithDistance
   {
     JunimoHut,
@@ -302,7 +500,10 @@ internal class ShowItemEffectRanges : IDisposable
     IridiumSprinkler,
     PrismaticSprinkler,
     MushroomLog,
-    MossySeed
+    MossySeed,
+    CherryBomb,
+    Bomb,
+    MegaBomb
   }
 
   private int[][] GetDistanceArray(ObjectsWithDistance type, bool hasPressureNozzle = false, Object? instance = null)
@@ -333,6 +534,12 @@ internal class ShowItemEffectRanges : IDisposable
         return GetCircularMask(100, maxDisplaySquareRadius: 7);
       case ObjectsWithDistance.MossySeed:
         return GetCircularMask(100, maxDisplaySquareRadius: 5);
+      case ObjectsWithDistance.CherryBomb:
+        return GetCircularMask(3.39);
+      case ObjectsWithDistance.Bomb:
+        return GetCircularMask(5.52);
+      case ObjectsWithDistance.MegaBomb:
+        return GetCircularMask(7.45);
       default:
         return null;
     }
@@ -390,6 +597,6 @@ internal class ShowItemEffectRanges : IDisposable
   {
     return Math.Sqrt((radius - i) * (radius - i) + (radius - j) * (radius - j));
   }
-#endregion
-#endregion
+  #endregion
+  #endregion
 }

--- a/UIInfoSuite2/i18n/default.json
+++ b/UIInfoSuite2/i18n/default.json
@@ -1,6 +1,13 @@
-{
+﻿{
   // GUI - Game Menu
   "OptionsTabTooltip": "UI Info Suite 2 Options",
+  // some config options
+  "Keybinds.Subtitle.ShowRange.displayedName": "Show item effect ranges",
+  "Keybinds.Subtitle.ShowRange.Tooltip": "Such: scarecrow, sprinkler, Junimo Hut, bee house, mushroom log and mossy seed.",
+  "Keybinds.ShowOneRange.DisplayedName": "Show current item range",
+  "Keybinds.ShowOneRange.Tooltip": "When the mouse moves over the item you want to show, show range.",
+  "Keybinds.ShowAllRange.DisplayedName": "Show all item range",
+  "Keybinds.ShowAllRange.Tooltip": "When the mouse moves over the item you want to show, all ranges are show.",
   //GUI - Billboard
   "Billboard": "Billboard",
   "Calendar": "Calendar",
@@ -79,6 +86,8 @@
   "HideAnimalPetOnMaxFriendship": "Hide on max friendship",
   "ShowCropAndBarrelTooltip": "Show crop and barrel times",
   "ShowItemEffectRanges": "Show scarecrow and sprinkler range",
+  "ButtonControlShow": "Press leftctrl to show current item range, while pressing leftalt to show all item range",
+  "ShowBombRange": "Show the bomb destroying Range",
   "ShowExtraItemInformation": "Show item hover information",
   "ShowHarvestPricesInShop": "Show shop harvest prices",
   //Settings - Tabs info

--- a/UIInfoSuite2/i18n/zh.json
+++ b/UIInfoSuite2/i18n/zh.json
@@ -1,6 +1,13 @@
-{
+﻿{
   // GUI - Game Menu
   "OptionsTabTooltip": "UI Info Suite 2 选项",
+  // some config options
+  "Keybinds.Subtitle.ShowRange.displayedName": "显示物品效果范围",
+  "Keybinds.Subtitle.ShowRange.Tooltip": "例如：稻草人、洒水器、祝尼魔屋、蜂房、蘑菇树桩和长满苔藓的种子。",
+  "Keybinds.ShowOneRange.DisplayedName": "显示单个范围",
+  "Keybinds.ShowOneRange.Tooltip": "当鼠标移至需要显示的物品上时，显示范围。",
+  "Keybinds.ShowAllRange.DisplayedName": "显示全部范围",
+  "Keybinds.ShowAllRange.Tooltip": "当鼠标移至需要显示的物品上时，显示所有范围。",
   //GUI - Billboard
   "Billboard": "布告栏",
   "Calendar": "日历",
@@ -41,7 +48,7 @@
   "ToolIsFinishedBeingUpgraded": "{0}完成了！",
   "NpcBirthday": "{0}的生日",
   "RobinBuildingStatus": "罗宾将在 {0} 天内完成你的新建筑",
-  "RobinHouseUpgradeStatus": "罗宾将在 {0} 天内完成升级你的房子", 
+  "RobinHouseUpgradeStatus": "罗宾将在 {0} 天内完成升级你的房子",
   // Display icons - Foragables
   "CanFindSalmonberry": "今天可以找到美洲大树莓",
   "CanFindBlackberry": "今天可以找到黑莓",
@@ -68,6 +75,8 @@
   "HideAnimalPetOnMaxFriendship": "在动物达到最大心情时隐藏",
   "ShowCropAndBarrelTooltip": "显示作物与桶的剩余时间",
   "ShowItemEffectRanges": "显示稻草人与洒水器的范围",
+  "ButtonControlShow": "按下LeftCtrl显示当前，同时按下LeftAlt显示全部",
+  "ShowBombRange": "显示炸弹摧毁范围",
   "ShowExtraItemInformation": "鼠标悬停时显示物品信息",
   "ShowHarvestPricesInShop": "在购买页面显示收获价格",
   //Settings - Tabs info


### PR DESCRIPTION
1. When the mouse is over an item, press leftCtrl to show only that range, and press both leftCtrl and leftAlt to show the full range.
2. Display overlapping ranges of multiple devices, but only overlaps of the current item range are shown And replace it with another color.